### PR TITLE
Fix: add class_name: Container to leonardo container config so it’s parsed as ContainerConfig

### DIFF
--- a/config/container/leonardo.yaml
+++ b/config/container/leonardo.yaml
@@ -1,3 +1,4 @@
+class_name: Container
 image: ${oc.env:CONTAINER_CACHE_DIR,.}/MegatronTraining_x86_64_202512291044.sif
 runtime: singularity
 bind: ["/leonardo_scratch", "/leonardo"]


### PR DESCRIPTION
Launching the tool with `python scripts/run_autoexp.py --config-name experiments/megatron_leonardo_speed_test` failed because the container section wasn't parsed as ContainerConfig object.
```
	File "/leonardo_work/OELLM_prod2026/users/donutu00/oellm-autoexp/oellm_autoexp/config/schema.py", line 102, in __post_init__
	    assert self.slurm.env["MACHINE_NAME"] == self.container.env["MACHINE_NAME"]
	                                             ^^^^^^^^^^^^^^^^^^
	AttributeError: 'dict' object has no attribute 'env'
```
