### PR TITLE
Vmjkom/issue25

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ The environment variables used in the `config/` here are:
     # using uv
     curl -LsSf https://astral.sh/uv/install.sh | sh
     # uv creates a python virtual environment matching pyproject.toml-file on the fly. inode-count for env ~2k.
-    SLURM_ACCOUNT=project_462000963 SLURM_PARTITION=dev-g uv run --python 3.12 python scripts/run_autoexp.py --config-name experiments/megatron_lumi_speed_test.yaml  
-    
+    SLURM_ACCOUNT=project_462000963 SLURM_PARTITION=dev-g uv run --python 3.12 python scripts/run_autoexp.py --config-name experiments/megatron_lumi_speed_test.yaml
+
 
 ## Cluster setup: MARENOSTRUM notes
 You need to install oellm-autoexp or its requirements in a conda environment to run it on MARENOSTRUM. To do this:

--- a/oellm_autoexp/orchestrator.py
+++ b/oellm_autoexp/orchestrator.py
@@ -34,6 +34,8 @@ from oellm_autoexp.config.schema import (
     PostProcessStepInterface,
     ContainerConfig,
 )
+from oellm_autoexp.slurm_gen.generator import generate_script
+from oellm_autoexp.slurm_gen.validator import validate_job_script
 
 
 LOGGER = logging.getLogger(__name__)
@@ -100,10 +102,16 @@ def submit_jobs(
     session_id: str | None = None,
     no_error_catching: bool = False,
     local_mode: bool = False,
+    dry_run: bool = False,
+    no_monitor: bool | None = None,
 ) -> SubmissionResult:
-    store, session_id = _ensure_state_store(plan, session_id=session_id)
+    # If no_monitor is not explicitly set, default to True if dry_run is True, otherwise False.
+    if no_monitor is None:
+        no_monitor = dry_run
     client = slurm_client or SlurmClient(SlurmClientConfig())
     local_client = LocalCommandClient(LocalCommandClientConfig())
+    if not no_monitor:
+        store, session_id = _ensure_state_store(plan, session_id=session_id)
     loop = MonitorLoop(
         store, slurm_client=client, local_client=local_client, no_error_catching=no_error_catching
     )
@@ -111,6 +119,11 @@ def submit_jobs(
     submitted_job_ids: list[str] = []
     for job in plan.jobs:
         record = _build_job_record(plan, job, session_id, local_mode=local_mode)
+
+        if dry_run and isinstance(record.definition, SlurmJobConfig):
+            path = generate_script(record.definition.slurm)
+            LOGGER.info("DRY RUN - Generated batch script: %s", path)
+            #TODO: Might aswell validate the job script and therein megatron arguments here
         store.upsert(record)
         submitted_job_ids.append(record.job_id)
 
@@ -296,7 +309,6 @@ def _build_job_record(
         slurm=slurm_config,
         base_config=job,
     )
-
     return JobRecordConfig(
         job_id=job_id,
         definition=definition,

--- a/oellm_autoexp/orchestrator.py
+++ b/oellm_autoexp/orchestrator.py
@@ -35,7 +35,6 @@ from oellm_autoexp.config.schema import (
     ContainerConfig,
 )
 from oellm_autoexp.slurm_gen.generator import generate_script
-from oellm_autoexp.slurm_gen.validator import validate_job_script
 
 
 LOGGER = logging.getLogger(__name__)
@@ -103,15 +102,10 @@ def submit_jobs(
     no_error_catching: bool = False,
     local_mode: bool = False,
     dry_run: bool = False,
-    no_monitor: bool | None = None,
 ) -> SubmissionResult:
-    # If no_monitor is not explicitly set, default to True if dry_run is True, otherwise False.
-    if no_monitor is None:
-        no_monitor = dry_run
+    store, session_id = _ensure_state_store(plan, session_id=session_id)
     client = slurm_client or SlurmClient(SlurmClientConfig())
     local_client = LocalCommandClient(LocalCommandClientConfig())
-    if not no_monitor:
-        store, session_id = _ensure_state_store(plan, session_id=session_id)
     loop = MonitorLoop(
         store, slurm_client=client, local_client=local_client, no_error_catching=no_error_catching
     )
@@ -123,7 +117,7 @@ def submit_jobs(
         if dry_run and isinstance(record.definition, SlurmJobConfig):
             path = generate_script(record.definition.slurm)
             LOGGER.info("DRY RUN - Generated batch script: %s", path)
-            #TODO: Might aswell validate the job script and therein megatron arguments here
+            # TODO: Might aswell validate the job script and therein megatron arguments here
         store.upsert(record)
         submitted_job_ids.append(record.job_id)
 

--- a/scripts/run_autoexp.py
+++ b/scripts/run_autoexp.py
@@ -207,12 +207,13 @@ def main(argv: list[str] | None = None) -> None:
 
     if args.dry_run:
         return
+    
     #if args.no_monitor:
     #    exit(0)
 
-    #if args.submit_and_exit:
-    #    res.loop.observe_once()
-    #    exit(0)
+    if args.submit_and_exit:
+        res.loop.observe_once()
+        exit(0)
 
     run_loop(res.loop)
 

--- a/scripts/run_autoexp.py
+++ b/scripts/run_autoexp.py
@@ -24,6 +24,8 @@ from oellm_autoexp.orchestrator import (
     submit_jobs,
     run_loop,
 )
+from oellm_autoexp.slurm_gen.generator import generate_script
+from oellm_autoexp.slurm_gen.validator import validate_job_script
 from oellm_autoexp.utils.logging_config import configure_logging
 
 
@@ -194,9 +196,6 @@ def main(argv: list[str] | None = None) -> None:
         subset_indices=subset_indices or None,
     )
 
-    if args.dry_run:
-        exit(0)
-
     _write_job_provenance(
         plan,
         args=args,
@@ -204,14 +203,16 @@ def main(argv: list[str] | None = None) -> None:
         overrides=args.overrides,
     )
 
-    res = submit_jobs(plan, no_error_catching=args.debug, local_mode=args.local)
+    res = submit_jobs(plan, no_error_catching=args.debug, local_mode=args.local,dry_run=args.dry_run,no_monitor=args.no_monitor)
 
-    if args.no_monitor:
-        exit(0)
+    if args.dry_run:
+        return
+    #if args.no_monitor:
+    #    exit(0)
 
-    if args.submit_and_exit:
-        res.loop.observe_once()
-        exit(0)
+    #if args.submit_and_exit:
+    #    res.loop.observe_once()
+    #    exit(0)
 
     run_loop(res.loop)
 

--- a/scripts/run_autoexp.py
+++ b/scripts/run_autoexp.py
@@ -208,8 +208,8 @@ def main(argv: list[str] | None = None) -> None:
     if args.dry_run:
         return
 
-    # if args.no_monitor:
-    #    exit(0)
+    if args.no_monitor:
+        exit(0)
 
     if args.submit_and_exit:
         res.loop.observe_once()

--- a/scripts/run_autoexp.py
+++ b/scripts/run_autoexp.py
@@ -24,8 +24,6 @@ from oellm_autoexp.orchestrator import (
     submit_jobs,
     run_loop,
 )
-from oellm_autoexp.slurm_gen.generator import generate_script
-from oellm_autoexp.slurm_gen.validator import validate_job_script
 from oellm_autoexp.utils.logging_config import configure_logging
 
 
@@ -203,12 +201,14 @@ def main(argv: list[str] | None = None) -> None:
         overrides=args.overrides,
     )
 
-    res = submit_jobs(plan, no_error_catching=args.debug, local_mode=args.local,dry_run=args.dry_run,no_monitor=args.no_monitor)
+    res = submit_jobs(
+        plan, no_error_catching=args.debug, local_mode=args.local, dry_run=args.dry_run
+    )
 
     if args.dry_run:
         return
-    
-    #if args.no_monitor:
+
+    # if args.no_monitor:
     #    exit(0)
 
     if args.submit_and_exit:


### PR DESCRIPTION
Fixes #25 . I'm thinking whether this fix should include the feature for validating megatron arguments when `--dry-run` is used. Also, right now there seems to be redundancy between arguments `--no-monitor` and `--submit_and_exit`, so fix to this could be included aswell.