### PR TITLE
updating progress tracker

### DIFF
--- a/oellm_autoexp/slurm_gen/generator.py
+++ b/oellm_autoexp/slurm_gen/generator.py
@@ -13,7 +13,8 @@ from oellm_autoexp.slurm_gen.template_renderer import render_template_file
 def build_sbatch_directives(config: SlurmConfig) -> list[str]:
     directives: list[str] = []
     sbatch_values = asdict(config.sbatch)
-    del sbatch_values["_non_strict"]
+    if "_non_strict" in sbatch_values:
+        del sbatch_values["_non_strict"]
     jobname_present = False
     for key, value in sbatch_values.items():
         if key == "job_name" and value is not None:

--- a/scripts/validate_sweep_runs.py
+++ b/scripts/validate_sweep_runs.py
@@ -1,0 +1,169 @@
+"""
+Utilities shared between progress_tracker and any sweep-validation tooling.
+
+Provides:
+  _resolve_defaults          -- merge Hydra-style defaults into a parsed cfg dict
+  render_job_name            -- render a job-name template for a given combo/stage
+  substitute_omegaconf_path_vars -- substitute ${key} refs from a context dict
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+def _deep_merge(base: dict, override: dict) -> dict:
+    """Merge *override* into *base* in-place (nested dicts are merged recursively)."""
+    for k, v in override.items():
+        if k in base and isinstance(base[k], dict) and isinstance(v, dict):
+            _deep_merge(base[k], v)
+        else:
+            base[k] = v
+    return base
+
+
+def _find_config_root(config_path: str) -> Path:
+    """Walk up from config_path until we find the ancestor directory named 'config'."""
+    p = Path(config_path).resolve()
+    for ancestor in p.parents:
+        if ancestor.name == "config":
+            return ancestor
+    # fallback: assume config/experiments/.../file.yaml layout (4 levels up)
+    return p.parent.parent.parent.parent
+
+
+def _read_package(yaml_text: str) -> str | None:
+    """Return the value of a '# @package <name>' directive from the first 5 lines."""
+    for line in yaml_text.splitlines()[:5]:
+        m = re.match(r"#\s*@package\s+(\S+)", line)
+        if m:
+            return m.group(1)
+    return None
+
+
+def _navigate(cfg: dict, dotted_path: str) -> dict:
+    """Return (creating as needed) the nested dict at *dotted_path* inside *cfg*."""
+    node = cfg
+    for key in dotted_path.split("."):
+        if key not in node or not isinstance(node[key], dict):
+            node[key] = {}
+        node = node[key]
+    return node
+
+
+def _apply_default(cfg: dict, config_root: Path, raw_key: str, value: str) -> None:
+    """Load one defaults-list entry and merge it into *cfg*."""
+    # /sweep/multilingual_scaling@sweep → group=sweep/multilingual_scaling, pkg_override=sweep
+    if "@" in raw_key:
+        config_group, pkg_override = raw_key.rsplit("@", 1)
+    else:
+        config_group, pkg_override = raw_key, None
+
+    config_group = config_group.strip("/")
+    yaml_file = config_root / config_group / f"{value}.yaml"
+    if not yaml_file.is_file():
+        return
+
+    text = yaml_file.read_text(errors="replace")
+    sub_cfg = yaml.safe_load(text) or {}
+
+    # Determine target package (in dotted form, e.g. "backend.megatron")
+    if pkg_override is not None:
+        package = pkg_override
+    else:
+        file_pkg = _read_package(text)
+        if file_pkg and file_pkg != "_global_":
+            package = file_pkg
+        else:
+            # infer from config group path: backend/megatron → backend.megatron
+            package = config_group.replace("/", ".")
+
+    target = _navigate(cfg, package) if package else cfg
+    _deep_merge(target, sub_cfg)
+
+    # Recurse into the sub-config's own defaults (one level only — enough for base.yaml)
+    for entry in sub_cfg.get("defaults", []):
+        if entry == "_self_" or isinstance(entry, str):
+            continue
+        if not isinstance(entry, dict):
+            continue
+        for sub_key, sub_val in entry.items():
+            # Resolve relative to the sub-config's directory
+            sub_root = yaml_file.parent
+            # Absolute keys start with /; relative keys are under the same group dir
+            if str(sub_key).startswith("/"):
+                _apply_default(cfg, config_root, sub_key, str(sub_val))
+            else:
+                rel_key = f"{config_group}/{sub_key}".strip("/")
+                _apply_default(cfg, config_root, f"/{rel_key}", str(sub_val))
+
+
+def _resolve_defaults(cfg: dict, config_path: str) -> None:
+    """Merge Hydra-style defaults list entries into *cfg* in-place.
+
+    Handles the subset needed by parse_config:
+      - sweep YAML (via the @sweep key)  → cfg["sweep"]
+      - model/data YAMLs with @package backend.megatron → cfg["backend"]["megatron"]
+    """
+    config_root = _find_config_root(config_path)
+    for entry in cfg.get("defaults", []):
+        if entry == "_self_" or isinstance(entry, str):
+            continue
+        if not isinstance(entry, dict):
+            continue
+        for raw_key, value in entry.items():
+            _apply_default(cfg, config_root, str(raw_key), str(value))
+
+
+# ── job-name rendering ─────────────────────────────────────────────────────────
+
+def substitute_omegaconf_path_vars(template: str, ctx: dict[str, Any]) -> str:
+    """Replace ${key} references in *template* with values from *ctx*.
+
+    Unresolvable references are left as-is.
+    """
+    def _replace(m: re.Match) -> str:
+        key = m.group(1)
+        return str(ctx[key]) if key in ctx else m.group(0)
+
+    return re.sub(r"\$\{([^}]+)\}", _replace, template)
+
+
+def render_job_name(
+    tpl: str,
+    num_experts: int,
+    lr: float,
+    gbsz: int,
+    seed: int,
+    stage: str,
+    tokens: int | None = None,
+) -> str:
+    """Render a job-name template for a given (lr, gbsz, stage, tokens) combo.
+
+    *tokens* is the stable-phase token budget (sets job_horizon_suffix to e.g.
+    "50BT").  For decay stages *tokens* is omitted — the suffix is empty because
+    the budget is already embedded in *stage* (e.g. "decay6BT").
+
+    The template uses escaped OmegaConf syntax (``\\${...}``) so that Hydra
+    doesn't interpolate it at config-load time; we unescape before substituting.
+    """
+    # Unescape \${ → ${
+    unescaped = tpl.replace("\\${", "${")
+
+    horizon_suffix = f"{tokens // 1_000_000_000}BT" if tokens is not None else ""
+
+    ctx: dict[str, Any] = {
+        "backend.megatron.lr":                  str(lr),
+        "backend.megatron.global_batch_size":   str(gbsz),
+        "backend.megatron.seed":                str(seed),
+        "backend.megatron.num_experts":         str(num_experts),
+        "stage":                                stage,
+        "backend.megatron.aux.job_horizon_suffix": horizon_suffix,
+    }
+    return substitute_omegaconf_path_vars(unescaped, ctx)

--- a/scripts/validate_sweep_runs.py
+++ b/scripts/validate_sweep_runs.py
@@ -1,5 +1,4 @@
-"""
-Utilities shared between progress_tracker and any sweep-validation tooling.
+"""Utilities shared between progress_tracker and any sweep-validation tooling.
 
 Provides:
   _resolve_defaults          -- merge Hydra-style defaults into a parsed cfg dict
@@ -18,8 +17,10 @@ import yaml
 
 # ── helpers ────────────────────────────────────────────────────────────────────
 
+
 def _deep_merge(base: dict, override: dict) -> dict:
-    """Merge *override* into *base* in-place (nested dicts are merged recursively)."""
+    """Merge *override* into *base* in-place (nested dicts are merged
+    recursively)."""
     for k, v in override.items():
         if k in base and isinstance(base[k], dict) and isinstance(v, dict):
             _deep_merge(base[k], v)
@@ -29,7 +30,8 @@ def _deep_merge(base: dict, override: dict) -> dict:
 
 
 def _find_config_root(config_path: str) -> Path:
-    """Walk up from config_path until we find the ancestor directory named 'config'."""
+    """Walk up from config_path until we find the ancestor directory named
+    'config'."""
     p = Path(config_path).resolve()
     for ancestor in p.parents:
         if ancestor.name == "config":
@@ -39,7 +41,8 @@ def _find_config_root(config_path: str) -> Path:
 
 
 def _read_package(yaml_text: str) -> str | None:
-    """Return the value of a '# @package <name>' directive from the first 5 lines."""
+    """Return the value of a '# @package <name>' directive from the first 5
+    lines."""
     for line in yaml_text.splitlines()[:5]:
         m = re.match(r"#\s*@package\s+(\S+)", line)
         if m:
@@ -48,7 +51,8 @@ def _read_package(yaml_text: str) -> str | None:
 
 
 def _navigate(cfg: dict, dotted_path: str) -> dict:
-    """Return (creating as needed) the nested dict at *dotted_path* inside *cfg*."""
+    """Return (creating as needed) the nested dict at *dotted_path* inside
+    *cfg*."""
     node = cfg
     for key in dotted_path.split("."):
         if key not in node or not isinstance(node[key], dict):
@@ -94,8 +98,6 @@ def _apply_default(cfg: dict, config_root: Path, raw_key: str, value: str) -> No
         if not isinstance(entry, dict):
             continue
         for sub_key, sub_val in entry.items():
-            # Resolve relative to the sub-config's directory
-            sub_root = yaml_file.parent
             # Absolute keys start with /; relative keys are under the same group dir
             if str(sub_key).startswith("/"):
                 _apply_default(cfg, config_root, sub_key, str(sub_val))
@@ -123,11 +125,13 @@ def _resolve_defaults(cfg: dict, config_path: str) -> None:
 
 # ── job-name rendering ─────────────────────────────────────────────────────────
 
+
 def substitute_omegaconf_path_vars(template: str, ctx: dict[str, Any]) -> str:
     """Replace ${key} references in *template* with values from *ctx*.
 
     Unresolvable references are left as-is.
     """
+
     def _replace(m: re.Match) -> str:
         key = m.group(1)
         return str(ctx[key]) if key in ctx else m.group(0)
@@ -159,11 +163,11 @@ def render_job_name(
     horizon_suffix = f"{tokens // 1_000_000_000}BT" if tokens is not None else ""
 
     ctx: dict[str, Any] = {
-        "backend.megatron.lr":                  str(lr),
-        "backend.megatron.global_batch_size":   str(gbsz),
-        "backend.megatron.seed":                str(seed),
-        "backend.megatron.num_experts":         str(num_experts),
-        "stage":                                stage,
+        "backend.megatron.lr": str(lr),
+        "backend.megatron.global_batch_size": str(gbsz),
+        "backend.megatron.seed": str(seed),
+        "backend.megatron.num_experts": str(num_experts),
+        "stage": stage,
         "backend.megatron.aux.job_horizon_suffix": horizon_suffix,
     }
     return substitute_omegaconf_path_vars(unescaped, ctx)

--- a/tools/extract_val_loss.py
+++ b/tools/extract_val_loss.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Extract the final validation loss from the latest .log file in each run
+subdirectory and write results to a CSV.
+
+Usage:
+    python collect_val_loss.py <runs_dir> [--output <output.csv>]
+"""
+
+import argparse
+import csv
+import re
+import sys
+from pathlib import Path
+
+VAL_LOSS_RE = re.compile(
+    r"validation loss at iteration\s+(\d+)\s+on validation set\s*\|.*?lm loss value:\s*([\d.E+\-]+)\s*\|.*?lm loss PPL:\s*([\d.E+\-]+)"
+)
+
+
+def find_latest_log(run_dir: Path) -> Path | None:
+    logs = [f for f in run_dir.iterdir() if f.suffix == ".log" and f.is_file()]
+    if not logs:
+        return None
+    return max(logs, key=lambda f: f.stat().st_mtime)
+
+
+def extract_last_val_loss(log_file: Path) -> tuple[int, float, float] | None:
+    last_match = None
+    with log_file.open(errors="replace") as f:
+        for line in f:
+            m = VAL_LOSS_RE.search(line)
+            if m:
+                last_match = m
+    if last_match is None:
+        return None
+    iteration = int(last_match.group(1))
+    loss = float(last_match.group(2))
+    ppl = float(last_match.group(3))
+    return iteration, loss, ppl
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Collect final validation loss from run directories."
+    )
+    parser.add_argument("runs_dir", type=Path, help="Directory containing run subdirectories")
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        default=None,
+        help="Output CSV file (default: <runs_dir>/val_loss_summary.csv)",
+    )
+    args = parser.parse_args()
+
+    if args.output is None:
+        args.output = args.runs_dir / "val_loss_summary.csv"
+
+    if not args.runs_dir.is_dir():
+        print(f"Error: {args.runs_dir} is not a directory", file=sys.stderr)
+        sys.exit(1)
+
+    run_dirs = sorted(d for d in args.runs_dir.iterdir() if d.is_dir())
+    if not run_dirs:
+        print(f"No subdirectories found in {args.runs_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    rows = []
+    for run_dir in run_dirs:
+        log_file = find_latest_log(run_dir)
+        if log_file is None:
+            print(f"  [skip] {run_dir.name}: no .log files found")
+            continue
+
+        result = extract_last_val_loss(log_file)
+        if result is None:
+            print(f"  [skip] {run_dir.name}: no validation loss found in {log_file.name}")
+            continue
+
+        iteration, loss, ppl = result
+        print(
+            f"  {run_dir.name}: iter={iteration}  loss={loss:.6E}  PPL={ppl:.6E}  ({log_file.name})"
+        )
+        rows.append(
+            {
+                "run_name": run_dir.name,
+                "iteration": iteration,
+                "lm_loss": loss,
+                "lm_loss_ppl": ppl,
+            }
+        )
+
+    if not rows:
+        print("No results collected — nothing written.", file=sys.stderr)
+        sys.exit(1)
+
+    with args.output.open("w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=["run_name", "iteration", "lm_loss", "lm_loss_ppl"])
+        writer.writeheader()
+        writer.writerows(rows)
+
+    print(f"\nWrote {len(rows)} rows to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/gpu_hours.py
+++ b/tools/gpu_hours.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
-"""Calculate GPU hours for all experiments in a results directory. Scans for
-slurm-<jobid>.log files, queries sacct, and reports per-job and per-experiment
-GPU-hours.
+"""
+Calculate GPU hours for all experiments in a results directory.
+Scans for slurm-<jobid>.log files, queries sacct, and reports per-job
+and per-experiment GPU-hours.
 
 Usage:
     python gpu_hours.py [results_dir]
@@ -60,21 +61,18 @@ def collect_job_ids(results_dir):
 
 
 def query_sacct(job_ids):
-    """Run sacct for the given job IDs.
-
+    """
+    Run sacct for the given job IDs.
     Returns {job_id: {"state": ..., "elapsed": ..., "gpus": int}}.
     Only the top-level job entry (no .batch / .extern / .N steps) is kept.
     """
     ids_str = ",".join(job_ids)
     cmd = [
-        "sacct",
-        "-j",
-        ids_str,
+        "sacct", "-j", ids_str,
         "--format=JobID,State,Elapsed,AllocTRES%80",
-        "--noheader",
-        "--parsable2",
+        "--noheader", "--parsable2",
     ]
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
     if result.returncode != 0:
         print(f"sacct error: {result.stderr.strip()}", file=sys.stderr)
         sys.exit(1)
@@ -103,21 +101,11 @@ def query_sacct(job_ids):
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="Calculate GPU hours for all experiments in a results directory."
-    )
-    parser.add_argument(
-        "results_dir",
-        nargs="?",
-        default=".",
-        help="Directory containing experiment subdirectories (default: current directory)",
-    )
-    parser.add_argument(
-        "--output",
-        "-o",
-        default=None,
-        help="Output CSV file (default: <results_dir>/gpu_hours.csv)",
-    )
+    parser = argparse.ArgumentParser(description="Calculate GPU hours for all experiments in a results directory.")
+    parser.add_argument("results_dir", nargs="?", default=".",
+                        help="Directory containing experiment subdirectories (default: current directory)")
+    parser.add_argument("--output", "-o", default=None,
+                        help="Output CSV file (default: <results_dir>/gpu_hours.csv)")
     args = parser.parse_args()
 
     results_dir = os.path.abspath(args.results_dir)
@@ -135,12 +123,12 @@ def main():
     sacct_info = query_sacct(all_job_ids)
 
     # ---- per-job table ----
-    col_exp = max(len(e) for e in experiments) + 2
-    col_job = 12
+    col_exp   = max(len(e) for e in experiments) + 2
+    col_job   = 12
     col_state = 20
-    col_ela = 14
-    col_gpu = 6
-    col_gpuh = 8
+    col_ela   = 14
+    col_gpu   = 6
+    col_gpuh  = 8
 
     header = (
         f"{'Experiment':<{col_exp}}  "
@@ -174,16 +162,14 @@ def main():
             hours = parse_elapsed(d["elapsed"])
             gpu_h = hours * d["gpus"]
             exp_total += gpu_h
-            csv_rows.append(
-                {
-                    "experiment": exp_name,
-                    "job_id": job_id,
-                    "state": d["state"],
-                    "elapsed": d["elapsed"],
-                    "gpus": d["gpus"],
-                    "gpu_hours": round(gpu_h, 1),
-                }
-            )
+            csv_rows.append({
+                "experiment": exp_name,
+                "job_id": job_id,
+                "state": d["state"],
+                "elapsed": d["elapsed"],
+                "gpus": d["gpus"],
+                "gpu_hours": round(gpu_h, 1),
+            })
             print(
                 f"{display_name:<{col_exp}}  "
                 f"{job_id:>{col_job}}  "
@@ -204,8 +190,7 @@ def main():
     for exp_name, job_ids in experiments.items():
         exp_gpu_h = sum(
             parse_elapsed(sacct_info[jid]["elapsed"]) * sacct_info[jid]["gpus"]
-            for jid in job_ids
-            if jid in sacct_info
+            for jid in job_ids if jid in sacct_info
         )
         print(f"  {exp_name:<{col_exp - 2}}  {exp_gpu_h:>8.1f} GPU-h")
 
@@ -214,21 +199,17 @@ def main():
     print(sep)
 
     # ---- save to CSV ----
-    csv_rows.append(
-        {
-            "experiment": "TOTAL",
-            "job_id": "",
-            "state": "",
-            "elapsed": "",
-            "gpus": "",
-            "gpu_hours": round(grand_total, 1),
-        }
-    )
+    csv_rows.append({
+        "experiment": "TOTAL",
+        "job_id": "",
+        "state": "",
+        "elapsed": "",
+        "gpus": "",
+        "gpu_hours": round(grand_total, 1),
+    })
     output_csv = args.output if args.output else os.path.join(results_dir, "gpu_hours.csv")
     with open(output_csv, "w", newline="") as f:
-        writer = csv.DictWriter(
-            f, fieldnames=["experiment", "job_id", "state", "elapsed", "gpus", "gpu_hours"]
-        )
+        writer = csv.DictWriter(f, fieldnames=["experiment", "job_id", "state", "elapsed", "gpus", "gpu_hours"])
         writer.writeheader()
         writer.writerows(csv_rows)
     print(f"\nWrote {len(csv_rows) - 1} job rows (+1 total) to {output_csv}")

--- a/tools/gpu_hours.py
+++ b/tools/gpu_hours.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
-"""
-Calculate GPU hours for all experiments in a results directory.
-Scans for slurm-<jobid>.log files, queries sacct, and reports per-job
-and per-experiment GPU-hours.
+"""Calculate GPU hours for all experiments in a results directory. Scans for
+slurm-<jobid>.log files, queries sacct, and reports per-job and per-experiment
+GPU-hours.
 
 Usage:
     python gpu_hours.py [results_dir]
@@ -61,18 +60,21 @@ def collect_job_ids(results_dir):
 
 
 def query_sacct(job_ids):
-    """
-    Run sacct for the given job IDs.
+    """Run sacct for the given job IDs.
+
     Returns {job_id: {"state": ..., "elapsed": ..., "gpus": int}}.
     Only the top-level job entry (no .batch / .extern / .N steps) is kept.
     """
     ids_str = ",".join(job_ids)
     cmd = [
-        "sacct", "-j", ids_str,
+        "sacct",
+        "-j",
+        ids_str,
         "--format=JobID,State,Elapsed,AllocTRES%80",
-        "--noheader", "--parsable2",
+        "--noheader",
+        "--parsable2",
     ]
-    result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+    result = subprocess.run(cmd, capture_output=True, text=True)
     if result.returncode != 0:
         print(f"sacct error: {result.stderr.strip()}", file=sys.stderr)
         sys.exit(1)
@@ -101,11 +103,21 @@ def query_sacct(job_ids):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Calculate GPU hours for all experiments in a results directory.")
-    parser.add_argument("results_dir", nargs="?", default=".",
-                        help="Directory containing experiment subdirectories (default: current directory)")
-    parser.add_argument("--output", "-o", default=None,
-                        help="Output CSV file (default: <results_dir>/gpu_hours.csv)")
+    parser = argparse.ArgumentParser(
+        description="Calculate GPU hours for all experiments in a results directory."
+    )
+    parser.add_argument(
+        "results_dir",
+        nargs="?",
+        default=".",
+        help="Directory containing experiment subdirectories (default: current directory)",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        default=None,
+        help="Output CSV file (default: <results_dir>/gpu_hours.csv)",
+    )
     args = parser.parse_args()
 
     results_dir = os.path.abspath(args.results_dir)
@@ -123,12 +135,12 @@ def main():
     sacct_info = query_sacct(all_job_ids)
 
     # ---- per-job table ----
-    col_exp   = max(len(e) for e in experiments) + 2
-    col_job   = 12
+    col_exp = max(len(e) for e in experiments) + 2
+    col_job = 12
     col_state = 20
-    col_ela   = 14
-    col_gpu   = 6
-    col_gpuh  = 8
+    col_ela = 14
+    col_gpu = 6
+    col_gpuh = 8
 
     header = (
         f"{'Experiment':<{col_exp}}  "
@@ -162,14 +174,16 @@ def main():
             hours = parse_elapsed(d["elapsed"])
             gpu_h = hours * d["gpus"]
             exp_total += gpu_h
-            csv_rows.append({
-                "experiment": exp_name,
-                "job_id": job_id,
-                "state": d["state"],
-                "elapsed": d["elapsed"],
-                "gpus": d["gpus"],
-                "gpu_hours": round(gpu_h, 1),
-            })
+            csv_rows.append(
+                {
+                    "experiment": exp_name,
+                    "job_id": job_id,
+                    "state": d["state"],
+                    "elapsed": d["elapsed"],
+                    "gpus": d["gpus"],
+                    "gpu_hours": round(gpu_h, 1),
+                }
+            )
             print(
                 f"{display_name:<{col_exp}}  "
                 f"{job_id:>{col_job}}  "
@@ -190,7 +204,8 @@ def main():
     for exp_name, job_ids in experiments.items():
         exp_gpu_h = sum(
             parse_elapsed(sacct_info[jid]["elapsed"]) * sacct_info[jid]["gpus"]
-            for jid in job_ids if jid in sacct_info
+            for jid in job_ids
+            if jid in sacct_info
         )
         print(f"  {exp_name:<{col_exp - 2}}  {exp_gpu_h:>8.1f} GPU-h")
 
@@ -199,17 +214,21 @@ def main():
     print(sep)
 
     # ---- save to CSV ----
-    csv_rows.append({
-        "experiment": "TOTAL",
-        "job_id": "",
-        "state": "",
-        "elapsed": "",
-        "gpus": "",
-        "gpu_hours": round(grand_total, 1),
-    })
+    csv_rows.append(
+        {
+            "experiment": "TOTAL",
+            "job_id": "",
+            "state": "",
+            "elapsed": "",
+            "gpus": "",
+            "gpu_hours": round(grand_total, 1),
+        }
+    )
     output_csv = args.output if args.output else os.path.join(results_dir, "gpu_hours.csv")
     with open(output_csv, "w", newline="") as f:
-        writer = csv.DictWriter(f, fieldnames=["experiment", "job_id", "state", "elapsed", "gpus", "gpu_hours"])
+        writer = csv.DictWriter(
+            f, fieldnames=["experiment", "job_id", "state", "elapsed", "gpus", "gpu_hours"]
+        )
         writer.writeheader()
         writer.writerows(csv_rows)
     print(f"\nWrote {len(csv_rows) - 1} job rows (+1 total) to {output_csv}")

--- a/tools/low_throughput_analysis.py
+++ b/tools/low_throughput_analysis.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-"""Analyze low-throughput iterations for all runs in a multilingual scaling
-experiment directory.
+"""
+Analyze low-throughput iterations for all runs in a multilingual scaling experiment directory.
 
 For each run (possibly spanning multiple Slurm jobs / restarts), reports:
   - time lost in low-throughput iterations (hours)
@@ -24,13 +24,14 @@ import subprocess
 import sys
 from pathlib import Path
 from statistics import mean
+from typing import Optional
 
 # Allow importing sibling modules when run as a script.
 _tools_dir = str(Path(__file__).parent)
 if _tools_dir not in sys.path:
     sys.path.insert(0, _tools_dir)
 
-from megatron_throughput_from_logs import load_or_compute_throughput  # noqa: E402
+from megatron_throughput_from_logs import load_or_compute_throughput
 
 # ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -52,10 +53,8 @@ RE_SBATCH_GRES = re.compile(r"^#SBATCH\s+--gres=gpu[^:\n]*:(\d+)", re.MULTILINE)
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
-
 def _parse_log_iterations(log_path: Path) -> list[tuple[int, float, float]]:
-    """Return sorted list of (iter_num, elapsed_ms, tflop_per_gpu) from a
-    stdout log."""
+    """Return sorted list of (iter_num, elapsed_ms, tflop_per_gpu) from a stdout log."""
     if not log_path.is_file():
         return []
     text = log_path.read_text(errors="replace")
@@ -66,9 +65,8 @@ def _parse_log_iterations(log_path: Path) -> list[tuple[int, float, float]]:
     return rows
 
 
-def _parse_sbatch_gpus(run_dir: Path) -> int | None:
-    """Return total GPU count (nodes × gpus-per-node) from job.sbatch, or
-    None."""
+def _parse_sbatch_gpus(run_dir: Path) -> Optional[int]:
+    """Return total GPU count (nodes × gpus-per-node) from job.sbatch, or None."""
     sbatch = run_dir / "job.sbatch"
     if not sbatch.is_file():
         return None
@@ -89,9 +87,8 @@ def _parse_sbatch_gpus(run_dir: Path) -> int | None:
     return None
 
 
-def _get_gpus_from_csv(run_name: str, gpu_hours_csv: Path) -> int | None:
-    """Return GPU count for *run_name* from gpu_hours.csv (first non-zero
-    entry)."""
+def _get_gpus_from_csv(run_name: str, gpu_hours_csv: Path) -> Optional[int]:
+    """Return GPU count for *run_name* from gpu_hours.csv (first non-zero entry)."""
     if not gpu_hours_csv.is_file():
         return None
     with gpu_hours_csv.open(newline="") as f:
@@ -107,25 +104,18 @@ def _get_gpus_from_csv(run_name: str, gpu_hours_csv: Path) -> int | None:
 
 
 def _ensure_gpu_hours_csv(training_dir: Path) -> Path:
-    """Return gpu_hours.csv path, generating it via gpu_hours.py if the file is
-    absent."""
+    """Return gpu_hours.csv path, generating it via gpu_hours.py if the file is absent."""
     csv_path = training_dir / "gpu_hours.csv"
     if csv_path.is_file():
         return csv_path
     gpu_hours_script = Path(__file__).parent / "gpu_hours.py"
     if gpu_hours_script.is_file():
-        print("[info] gpu_hours.csv not found — generating via gpu_hours.py ...", flush=True)
+        print(f"[info] gpu_hours.csv not found — generating via gpu_hours.py ...", flush=True)
         try:
             subprocess.run(
-                [
-                    sys.executable,
-                    str(gpu_hours_script),
-                    str(training_dir),
-                    "--output",
-                    str(csv_path),
-                ],
-                check=True,
-                timeout=120,
+                [sys.executable, str(gpu_hours_script), str(training_dir),
+                 "--output", str(csv_path)],
+                check=True, timeout=120,
             )
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
             print(f"[warn] gpu_hours.py failed: {exc}", file=sys.stderr)
@@ -134,10 +124,9 @@ def _ensure_gpu_hours_csv(training_dir: Path) -> Path:
 
 # ── Core analysis ─────────────────────────────────────────────────────────────
 
-
 def analyze_job(
     log_path: Path,
-    num_gpus: int | None = None,
+    num_gpus: Optional[int] = None,
     max_elapsed_ms: float = 6000.0,
     skip_first_iters: int = 50,
     max_iters_used: int = 500,
@@ -164,13 +153,8 @@ def analyze_job(
         avg_tflop    – reference average throughput (TFLOP/s/GPU)
         num_gpus     – GPU count used for the calculation
     """
-    empty = {
-        "time_lost_h": None,
-        "gpu_h_lost": None,
-        "n_low_iters": None,
-        "avg_tflop": None,
-        "num_gpus": num_gpus,
-    }
+    empty = {"time_lost_h": None, "gpu_h_lost": None,
+             "n_low_iters": None, "avg_tflop": None, "num_gpus": num_gpus}
 
     throughput = load_or_compute_throughput(
         log_path, max_elapsed_ms, skip_first_iters, max_iters_used
@@ -182,12 +166,16 @@ def analyze_job(
     threshold = avg_tflop * LOW_THROUGHPUT_FRACTION
 
     # Scan ALL iterations (no elapsed-time filter) to count and time low-TP events.
+    # Skip the first skip_first_iters so they are not double-counted with TTFI:
+    # TTFI is measured from job start through the timestamp of the first logged
+    # iteration, which includes the wall time of those warmup iters.
     rows = _parse_log_iterations(log_path)
     if not rows:
         return empty
 
-    low_elapsed_ms = sum(et for _it, et, tflop in rows if tflop < threshold)
-    n_low = sum(1 for _it, _et, tflop in rows if tflop < threshold)
+    rows_post_warmup = [(it, et, tflop) for it, et, tflop in rows if it > skip_first_iters]
+    low_elapsed_ms = sum(et for _it, et, tflop in rows_post_warmup if tflop < threshold)
+    n_low = sum(1 for _it, _et, tflop in rows_post_warmup if tflop < threshold)
 
     time_lost_h = low_elapsed_ms / 1_000 / 3_600
     gpu_h_lost = (time_lost_h * num_gpus) if num_gpus is not None else None
@@ -204,8 +192,8 @@ def analyze_job(
 def analyze_run(
     run_dir: Path,
     run_name: str,
-    gpu_hours_csv: Path | None = None,
-    num_gpus: int | None = None,
+    gpu_hours_csv: Optional[Path] = None,
+    num_gpus: Optional[int] = None,
     max_elapsed_ms: float = 6000.0,
     skip_first_iters: int = 50,
     max_iters_used: int = 500,
@@ -224,13 +212,8 @@ def analyze_run(
         skip_first_iters: Warmup iterations excluded from the reference average.
         max_iters_used:   Maximum post-warmup iterations averaged.
     """
-    empty = {
-        "time_lost_h": None,
-        "gpu_h_lost": None,
-        "n_low_iters": None,
-        "avg_tflop": None,
-        "num_gpus": None,
-    }
+    empty = {"time_lost_h": None, "gpu_h_lost": None,
+             "n_low_iters": None, "avg_tflop": None, "num_gpus": None}
 
     logs_dir = run_dir / "logs"
     if not logs_dir.is_dir():
@@ -246,15 +229,14 @@ def analyze_run(
         num_gpus = _get_gpus_from_csv(run_name, gpu_hours_csv)
 
     total_time_lost_h = 0.0
-    total_gpu_h_lost = 0.0
-    total_n_low = 0
+    total_gpu_h_lost  = 0.0
+    total_n_low       = 0
     avg_tflops: list[float] = []
     any_data = False
 
     for log_file in log_files:
         job_stats = analyze_job(
-            log_file,
-            num_gpus=num_gpus,
+            log_file, num_gpus=num_gpus,
             max_elapsed_ms=max_elapsed_ms,
             skip_first_iters=skip_first_iters,
             max_iters_used=max_iters_used,
@@ -274,15 +256,14 @@ def analyze_run(
 
     return {
         "time_lost_h": total_time_lost_h,
-        "gpu_h_lost": total_gpu_h_lost if num_gpus is not None else None,
+        "gpu_h_lost":  total_gpu_h_lost if num_gpus is not None else None,
         "n_low_iters": total_n_low,
-        "avg_tflop": mean(avg_tflops) if avg_tflops else None,
-        "num_gpus": num_gpus,
+        "avg_tflop":   mean(avg_tflops) if avg_tflops else None,
+        "num_gpus":    num_gpus,
     }
 
 
 # ── Directory-level analysis ──────────────────────────────────────────────────
-
 
 def analyze_experiment_dir(
     experiment_dir: Path,
@@ -292,8 +273,8 @@ def analyze_experiment_dir(
 ) -> list[dict]:
     """Analyze all runs under <experiment_dir>/training/.
 
-    Returns a list of dicts, one per run, each containing run_name plus
-    all keys returned by analyze_run().
+    Returns a list of dicts, one per run, each containing run_name plus all
+    keys returned by analyze_run().
     """
     training_dir = experiment_dir / "training"
     if not training_dir.is_dir():
@@ -308,9 +289,7 @@ def analyze_experiment_dir(
             continue
         run_name = run_dir.name
         stats = analyze_run(
-            run_dir,
-            run_name,
-            gpu_hours_csv,
+            run_dir, run_name, gpu_hours_csv,
             max_elapsed_ms=max_elapsed_ms,
             skip_first_iters=skip_first_iters,
             max_iters_used=max_iters_used,
@@ -322,7 +301,6 @@ def analyze_experiment_dir(
 
 
 # ── CLI ───────────────────────────────────────────────────────────────────────
-
 
 def main() -> None:
     ap = argparse.ArgumentParser(
@@ -376,21 +354,25 @@ def main() -> None:
 
     W = max(len(r["run_name"]) for r in results) + 2
 
-    header = f"{'Run':<{W}}  {'LowTP-Iters':>12}  {'AvgTFLOP':>9}  {'TimeLost(h)':>12}  {'GPU-h Lost':>11}  {'GPUs':>5}"
+    header = (
+        f"{'Run':<{W}}  {'LowTP-Iters':>12}  {'AvgTFLOP':>9}"
+        f"  {'TimeLost(h)':>12}  {'GPU-h Lost':>11}  {'GPUs':>5}"
+    )
     sep = "─" * len(header)
     print(sep)
     print(header)
     print(sep)
 
     for r in results:
-        n_str = str(r["n_low_iters"]) if r["n_low_iters"] is not None else "N/A"
-        avg_str = f"{r['avg_tflop']:.1f}" if r["avg_tflop"] is not None else "N/A"
-        tl_str = f"{r['time_lost_h']:.4f}" if r["time_lost_h"] is not None else "N/A"
-        gl_str = f"{r['gpu_h_lost']:.4f}" if r["gpu_h_lost"] is not None else "N/A"
-        gpus_str = str(r["num_gpus"]) if r["num_gpus"] is not None else "N/A"
+        n_str    = str(r["n_low_iters"])  if r["n_low_iters"]  is not None else "N/A"
+        avg_str  = f"{r['avg_tflop']:.1f}" if r["avg_tflop"]   is not None else "N/A"
+        tl_str   = f"{r['time_lost_h']:.4f}" if r["time_lost_h"] is not None else "N/A"
+        gl_str   = f"{r['gpu_h_lost']:.4f}"  if r["gpu_h_lost"]  is not None else "N/A"
+        gpus_str = str(r["num_gpus"])        if r["num_gpus"]    is not None else "N/A"
 
         print(
-            f"{r['run_name']:<{W}}  {n_str:>12}  {avg_str:>9}  {tl_str:>12}  {gl_str:>11}  {gpus_str:>5}"
+            f"{r['run_name']:<{W}}  {n_str:>12}  {avg_str:>9}"
+            f"  {tl_str:>12}  {gl_str:>11}  {gpus_str:>5}"
         )
 
     print(sep)

--- a/tools/low_throughput_analysis.py
+++ b/tools/low_throughput_analysis.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-"""
-Analyze low-throughput iterations for all runs in a multilingual scaling experiment directory.
+"""Analyze low-throughput iterations for all runs in a multilingual scaling
+experiment directory.
 
 For each run (possibly spanning multiple Slurm jobs / restarts), reports:
   - time lost in low-throughput iterations (hours)
@@ -24,14 +24,13 @@ import subprocess
 import sys
 from pathlib import Path
 from statistics import mean
-from typing import Optional
 
 # Allow importing sibling modules when run as a script.
 _tools_dir = str(Path(__file__).parent)
 if _tools_dir not in sys.path:
     sys.path.insert(0, _tools_dir)
 
-from megatron_throughput_from_logs import load_or_compute_throughput
+from megatron_throughput_from_logs import load_or_compute_throughput  # noqa: E402
 
 # ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -53,8 +52,10 @@ RE_SBATCH_GRES = re.compile(r"^#SBATCH\s+--gres=gpu[^:\n]*:(\d+)", re.MULTILINE)
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
+
 def _parse_log_iterations(log_path: Path) -> list[tuple[int, float, float]]:
-    """Return sorted list of (iter_num, elapsed_ms, tflop_per_gpu) from a stdout log."""
+    """Return sorted list of (iter_num, elapsed_ms, tflop_per_gpu) from a
+    stdout log."""
     if not log_path.is_file():
         return []
     text = log_path.read_text(errors="replace")
@@ -65,8 +66,9 @@ def _parse_log_iterations(log_path: Path) -> list[tuple[int, float, float]]:
     return rows
 
 
-def _parse_sbatch_gpus(run_dir: Path) -> Optional[int]:
-    """Return total GPU count (nodes × gpus-per-node) from job.sbatch, or None."""
+def _parse_sbatch_gpus(run_dir: Path) -> int | None:
+    """Return total GPU count (nodes × gpus-per-node) from job.sbatch, or
+    None."""
     sbatch = run_dir / "job.sbatch"
     if not sbatch.is_file():
         return None
@@ -87,8 +89,9 @@ def _parse_sbatch_gpus(run_dir: Path) -> Optional[int]:
     return None
 
 
-def _get_gpus_from_csv(run_name: str, gpu_hours_csv: Path) -> Optional[int]:
-    """Return GPU count for *run_name* from gpu_hours.csv (first non-zero entry)."""
+def _get_gpus_from_csv(run_name: str, gpu_hours_csv: Path) -> int | None:
+    """Return GPU count for *run_name* from gpu_hours.csv (first non-zero
+    entry)."""
     if not gpu_hours_csv.is_file():
         return None
     with gpu_hours_csv.open(newline="") as f:
@@ -104,18 +107,25 @@ def _get_gpus_from_csv(run_name: str, gpu_hours_csv: Path) -> Optional[int]:
 
 
 def _ensure_gpu_hours_csv(training_dir: Path) -> Path:
-    """Return gpu_hours.csv path, generating it via gpu_hours.py if the file is absent."""
+    """Return gpu_hours.csv path, generating it via gpu_hours.py if the file is
+    absent."""
     csv_path = training_dir / "gpu_hours.csv"
     if csv_path.is_file():
         return csv_path
     gpu_hours_script = Path(__file__).parent / "gpu_hours.py"
     if gpu_hours_script.is_file():
-        print(f"[info] gpu_hours.csv not found — generating via gpu_hours.py ...", flush=True)
+        print("[info] gpu_hours.csv not found — generating via gpu_hours.py ...", flush=True)
         try:
             subprocess.run(
-                [sys.executable, str(gpu_hours_script), str(training_dir),
-                 "--output", str(csv_path)],
-                check=True, timeout=120,
+                [
+                    sys.executable,
+                    str(gpu_hours_script),
+                    str(training_dir),
+                    "--output",
+                    str(csv_path),
+                ],
+                check=True,
+                timeout=120,
             )
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
             print(f"[warn] gpu_hours.py failed: {exc}", file=sys.stderr)
@@ -124,9 +134,10 @@ def _ensure_gpu_hours_csv(training_dir: Path) -> Path:
 
 # ── Core analysis ─────────────────────────────────────────────────────────────
 
+
 def analyze_job(
     log_path: Path,
-    num_gpus: Optional[int] = None,
+    num_gpus: int | None = None,
     max_elapsed_ms: float = 6000.0,
     skip_first_iters: int = 50,
     max_iters_used: int = 500,
@@ -153,8 +164,13 @@ def analyze_job(
         avg_tflop    – reference average throughput (TFLOP/s/GPU)
         num_gpus     – GPU count used for the calculation
     """
-    empty = {"time_lost_h": None, "gpu_h_lost": None,
-             "n_low_iters": None, "avg_tflop": None, "num_gpus": num_gpus}
+    empty = {
+        "time_lost_h": None,
+        "gpu_h_lost": None,
+        "n_low_iters": None,
+        "avg_tflop": None,
+        "num_gpus": num_gpus,
+    }
 
     throughput = load_or_compute_throughput(
         log_path, max_elapsed_ms, skip_first_iters, max_iters_used
@@ -192,8 +208,8 @@ def analyze_job(
 def analyze_run(
     run_dir: Path,
     run_name: str,
-    gpu_hours_csv: Optional[Path] = None,
-    num_gpus: Optional[int] = None,
+    gpu_hours_csv: Path | None = None,
+    num_gpus: int | None = None,
     max_elapsed_ms: float = 6000.0,
     skip_first_iters: int = 50,
     max_iters_used: int = 500,
@@ -212,8 +228,13 @@ def analyze_run(
         skip_first_iters: Warmup iterations excluded from the reference average.
         max_iters_used:   Maximum post-warmup iterations averaged.
     """
-    empty = {"time_lost_h": None, "gpu_h_lost": None,
-             "n_low_iters": None, "avg_tflop": None, "num_gpus": None}
+    empty = {
+        "time_lost_h": None,
+        "gpu_h_lost": None,
+        "n_low_iters": None,
+        "avg_tflop": None,
+        "num_gpus": None,
+    }
 
     logs_dir = run_dir / "logs"
     if not logs_dir.is_dir():
@@ -229,14 +250,15 @@ def analyze_run(
         num_gpus = _get_gpus_from_csv(run_name, gpu_hours_csv)
 
     total_time_lost_h = 0.0
-    total_gpu_h_lost  = 0.0
-    total_n_low       = 0
+    total_gpu_h_lost = 0.0
+    total_n_low = 0
     avg_tflops: list[float] = []
     any_data = False
 
     for log_file in log_files:
         job_stats = analyze_job(
-            log_file, num_gpus=num_gpus,
+            log_file,
+            num_gpus=num_gpus,
             max_elapsed_ms=max_elapsed_ms,
             skip_first_iters=skip_first_iters,
             max_iters_used=max_iters_used,
@@ -256,14 +278,15 @@ def analyze_run(
 
     return {
         "time_lost_h": total_time_lost_h,
-        "gpu_h_lost":  total_gpu_h_lost if num_gpus is not None else None,
+        "gpu_h_lost": total_gpu_h_lost if num_gpus is not None else None,
         "n_low_iters": total_n_low,
-        "avg_tflop":   mean(avg_tflops) if avg_tflops else None,
-        "num_gpus":    num_gpus,
+        "avg_tflop": mean(avg_tflops) if avg_tflops else None,
+        "num_gpus": num_gpus,
     }
 
 
 # ── Directory-level analysis ──────────────────────────────────────────────────
+
 
 def analyze_experiment_dir(
     experiment_dir: Path,
@@ -273,8 +296,8 @@ def analyze_experiment_dir(
 ) -> list[dict]:
     """Analyze all runs under <experiment_dir>/training/.
 
-    Returns a list of dicts, one per run, each containing run_name plus all
-    keys returned by analyze_run().
+    Returns a list of dicts, one per run, each containing run_name plus
+    all keys returned by analyze_run().
     """
     training_dir = experiment_dir / "training"
     if not training_dir.is_dir():
@@ -289,7 +312,9 @@ def analyze_experiment_dir(
             continue
         run_name = run_dir.name
         stats = analyze_run(
-            run_dir, run_name, gpu_hours_csv,
+            run_dir,
+            run_name,
+            gpu_hours_csv,
             max_elapsed_ms=max_elapsed_ms,
             skip_first_iters=skip_first_iters,
             max_iters_used=max_iters_used,
@@ -301,6 +326,7 @@ def analyze_experiment_dir(
 
 
 # ── CLI ───────────────────────────────────────────────────────────────────────
+
 
 def main() -> None:
     ap = argparse.ArgumentParser(
@@ -364,11 +390,11 @@ def main() -> None:
     print(sep)
 
     for r in results:
-        n_str    = str(r["n_low_iters"])  if r["n_low_iters"]  is not None else "N/A"
-        avg_str  = f"{r['avg_tflop']:.1f}" if r["avg_tflop"]   is not None else "N/A"
-        tl_str   = f"{r['time_lost_h']:.4f}" if r["time_lost_h"] is not None else "N/A"
-        gl_str   = f"{r['gpu_h_lost']:.4f}"  if r["gpu_h_lost"]  is not None else "N/A"
-        gpus_str = str(r["num_gpus"])        if r["num_gpus"]    is not None else "N/A"
+        n_str = str(r["n_low_iters"]) if r["n_low_iters"] is not None else "N/A"
+        avg_str = f"{r['avg_tflop']:.1f}" if r["avg_tflop"] is not None else "N/A"
+        tl_str = f"{r['time_lost_h']:.4f}" if r["time_lost_h"] is not None else "N/A"
+        gl_str = f"{r['gpu_h_lost']:.4f}" if r["gpu_h_lost"] is not None else "N/A"
+        gpus_str = str(r["num_gpus"]) if r["num_gpus"] is not None else "N/A"
 
         print(
             f"{r['run_name']:<{W}}  {n_str:>12}  {avg_str:>9}"

--- a/tools/megatron_throughput_from_logs.py
+++ b/tools/megatron_throughput_from_logs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-"""Parse Megatron stdout logs for per-GPU TFLOP/s and token/s, then print a
-summary table.
+"""
+Parse Megatron stdout logs for per-GPU TFLOP/s and token/s, then print a summary table.
 
 Looks for ``qwen3_*`` experiment subdirectories under each given base directory, reads
 ``logs/stdout*.log`` first (fallback: ``*.log`` in the run directory). When multiple
@@ -60,8 +60,7 @@ NAME_GBS = re.compile(r"gbsz(\d+)_")
 
 
 def filter_readable(paths: list[str]) -> list[str]:
-    """Drop missing paths / broken symlinks (common for ``current.log`` before
-    job writes)."""
+    """Drop missing paths / broken symlinks (common for ``current.log`` before job writes)."""
     return sorted(p for p in paths if Path(p).is_file())
 
 
@@ -73,8 +72,7 @@ def pick_stdout_log(log_paths: list[str]) -> str:
         raise FileNotFoundError("no readable log files in candidate list")
 
     def score(path: str) -> tuple[int, int]:
-        """Prefer latest Slurm job id (stdout-JOBID.log); tie-break on larger
-        file."""
+        """Prefer latest Slurm job id (stdout-JOBID.log); tie-break on larger file."""
         path_obj = Path(path)
         m = re.search(r"stdout-(\d+)\.log$", path_obj.name, re.I)
         job_id = int(m.group(1)) if m else -1
@@ -133,21 +131,13 @@ _ITER_FIELDS = ("iter_num", "elapsed_ms", "tflop_per_gpu", "tok_per_gpu")
 # Columns in avg_throughput.csv.  Data fields start at index 4 (after the
 # four param columns: job_id, max_elapsed_ms, skip_first_iters, max_iters_used).
 _AVG_FIELDS = (
-    "job_id",
-    "max_elapsed_ms",
-    "skip_first_iters",
-    "max_iters_used",
-    "n_iters",
-    "it_first",
-    "it_last",
-    "avg_tflop_per_gpu",
-    "avg_tok_per_gpu",
-    "avg_elapsed_ms",
+    "job_id", "max_elapsed_ms", "skip_first_iters", "max_iters_used",
+    "n_iters", "it_first", "it_last",
+    "avg_tflop_per_gpu", "avg_tok_per_gpu", "avg_elapsed_ms",
 )
 _AVG_DATA_FIELDS = _AVG_FIELDS[4:]
-_AVG_INT_FIELDS = frozenset(
-    {"skip_first_iters", "max_iters_used", "n_iters", "it_first", "it_last"}
-)
+_AVG_INT_FIELDS  = frozenset({"skip_first_iters", "max_iters_used",
+                               "n_iters", "it_first", "it_last"})
 
 
 def _throughput_dir(log_path: Path) -> Path:
@@ -166,7 +156,8 @@ def _parse_all_iters(log_path: Path) -> list[tuple[int, float, float, float]]:
     text = log_path.read_text(errors="replace")
     rows: list[tuple[int, float, float, float]] = []
     for m in ITER_LINE.finditer(text):
-        rows.append((int(m.group(1)), float(m.group(2)), float(m.group(3)), float(m.group(4))))
+        rows.append((int(m.group(1)), float(m.group(2)),
+                     float(m.group(3)), float(m.group(4))))
     rows.sort(key=lambda x: x[0])
     return rows
 
@@ -188,9 +179,8 @@ def _load_avg_row(
     max_elapsed_ms: float,
     skip_first_iters: int,
     max_iters_used: int,
-) -> dict[str, Any] | None:
-    """Return cached averages for *job_id* if stored params match, else
-    None."""
+) -> "dict[str, Any] | None":
+    """Return cached averages for *job_id* if stored params match, else None."""
     if not avg_csv.is_file():
         return None
     try:
@@ -215,17 +205,17 @@ def _load_avg_row(
 def _upsert_avg_row(
     avg_csv: Path,
     job_id: str,
-    result: dict[str, Any],
+    result: "dict[str, Any]",
     max_elapsed_ms: float,
     skip_first_iters: int,
     max_iters_used: int,
 ) -> None:
     """Write or replace the row for *job_id* in avg_throughput.csv."""
     new_row: dict[str, Any] = {
-        "job_id": job_id,
-        "max_elapsed_ms": max_elapsed_ms,
+        "job_id":           job_id,
+        "max_elapsed_ms":   max_elapsed_ms,
         "skip_first_iters": skip_first_iters,
-        "max_iters_used": max_iters_used,
+        "max_iters_used":   max_iters_used,
         **{k: result[k] for k in _AVG_DATA_FIELDS},
     }
     existing: list[dict] = []
@@ -251,7 +241,7 @@ def load_or_compute_throughput(
     max_elapsed_ms: float = 6000.0,
     skip_first_iters: int = 50,
     max_iters_used: int = 500,
-) -> dict[str, Any] | None:
+) -> "dict[str, Any] | None":
     """Return per-GPU throughput metrics for *log_path*, with CSV caching.
 
     Cache layout inside ``<run_dir>/throughput/`` (sibling of ``logs/``):
@@ -267,9 +257,9 @@ def load_or_compute_throughput(
     ``avg_tflop_per_gpu``, ``avg_tok_per_gpu``, ``avg_elapsed_ms``,
     or ``None`` if the log cannot be parsed.
     """
-    tp_dir = _throughput_dir(log_path)
+    tp_dir  = _throughput_dir(log_path)
     avg_csv = tp_dir / "avg_throughput.csv"
-    job_id = _job_id_from_log(log_path)
+    job_id  = _job_id_from_log(log_path)
 
     cached = _load_avg_row(avg_csv, job_id, max_elapsed_ms, skip_first_iters, max_iters_used)
     if cached is not None:
@@ -316,8 +306,7 @@ def gpu_count_from_path(
 
 
 def parse_sbatch(path: Path) -> tuple[int | None, int | None]:
-    """Return (nodes, gpus_per_node) from a SLURM sbatch file, or (None, None)
-    if absent."""
+    """Return (nodes, gpus_per_node) from a SLURM sbatch file, or (None, None) if absent."""
     if not path.is_file():
         return None, None
     text = path.read_text(errors="replace")

--- a/tools/megatron_throughput_from_logs.py
+++ b/tools/megatron_throughput_from_logs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-"""
-Parse Megatron stdout logs for per-GPU TFLOP/s and token/s, then print a summary table.
+"""Parse Megatron stdout logs for per-GPU TFLOP/s and token/s, then print a
+summary table.
 
 Looks for ``qwen3_*`` experiment subdirectories under each given base directory, reads
 ``logs/stdout*.log`` first (fallback: ``*.log`` in the run directory). When multiple
@@ -60,7 +60,8 @@ NAME_GBS = re.compile(r"gbsz(\d+)_")
 
 
 def filter_readable(paths: list[str]) -> list[str]:
-    """Drop missing paths / broken symlinks (common for ``current.log`` before job writes)."""
+    """Drop missing paths / broken symlinks (common for ``current.log`` before
+    job writes)."""
     return sorted(p for p in paths if Path(p).is_file())
 
 
@@ -72,7 +73,8 @@ def pick_stdout_log(log_paths: list[str]) -> str:
         raise FileNotFoundError("no readable log files in candidate list")
 
     def score(path: str) -> tuple[int, int]:
-        """Prefer latest Slurm job id (stdout-JOBID.log); tie-break on larger file."""
+        """Prefer latest Slurm job id (stdout-JOBID.log); tie-break on larger
+        file."""
         path_obj = Path(path)
         m = re.search(r"stdout-(\d+)\.log$", path_obj.name, re.I)
         job_id = int(m.group(1)) if m else -1
@@ -131,13 +133,21 @@ _ITER_FIELDS = ("iter_num", "elapsed_ms", "tflop_per_gpu", "tok_per_gpu")
 # Columns in avg_throughput.csv.  Data fields start at index 4 (after the
 # four param columns: job_id, max_elapsed_ms, skip_first_iters, max_iters_used).
 _AVG_FIELDS = (
-    "job_id", "max_elapsed_ms", "skip_first_iters", "max_iters_used",
-    "n_iters", "it_first", "it_last",
-    "avg_tflop_per_gpu", "avg_tok_per_gpu", "avg_elapsed_ms",
+    "job_id",
+    "max_elapsed_ms",
+    "skip_first_iters",
+    "max_iters_used",
+    "n_iters",
+    "it_first",
+    "it_last",
+    "avg_tflop_per_gpu",
+    "avg_tok_per_gpu",
+    "avg_elapsed_ms",
 )
 _AVG_DATA_FIELDS = _AVG_FIELDS[4:]
-_AVG_INT_FIELDS  = frozenset({"skip_first_iters", "max_iters_used",
-                               "n_iters", "it_first", "it_last"})
+_AVG_INT_FIELDS = frozenset(
+    {"skip_first_iters", "max_iters_used", "n_iters", "it_first", "it_last"}
+)
 
 
 def _throughput_dir(log_path: Path) -> Path:
@@ -156,8 +166,7 @@ def _parse_all_iters(log_path: Path) -> list[tuple[int, float, float, float]]:
     text = log_path.read_text(errors="replace")
     rows: list[tuple[int, float, float, float]] = []
     for m in ITER_LINE.finditer(text):
-        rows.append((int(m.group(1)), float(m.group(2)),
-                     float(m.group(3)), float(m.group(4))))
+        rows.append((int(m.group(1)), float(m.group(2)), float(m.group(3)), float(m.group(4))))
     rows.sort(key=lambda x: x[0])
     return rows
 
@@ -179,8 +188,9 @@ def _load_avg_row(
     max_elapsed_ms: float,
     skip_first_iters: int,
     max_iters_used: int,
-) -> "dict[str, Any] | None":
-    """Return cached averages for *job_id* if stored params match, else None."""
+) -> dict[str, Any] | None:
+    """Return cached averages for *job_id* if stored params match, else
+    None."""
     if not avg_csv.is_file():
         return None
     try:
@@ -205,17 +215,17 @@ def _load_avg_row(
 def _upsert_avg_row(
     avg_csv: Path,
     job_id: str,
-    result: "dict[str, Any]",
+    result: dict[str, Any],
     max_elapsed_ms: float,
     skip_first_iters: int,
     max_iters_used: int,
 ) -> None:
     """Write or replace the row for *job_id* in avg_throughput.csv."""
     new_row: dict[str, Any] = {
-        "job_id":           job_id,
-        "max_elapsed_ms":   max_elapsed_ms,
+        "job_id": job_id,
+        "max_elapsed_ms": max_elapsed_ms,
         "skip_first_iters": skip_first_iters,
-        "max_iters_used":   max_iters_used,
+        "max_iters_used": max_iters_used,
         **{k: result[k] for k in _AVG_DATA_FIELDS},
     }
     existing: list[dict] = []
@@ -241,7 +251,7 @@ def load_or_compute_throughput(
     max_elapsed_ms: float = 6000.0,
     skip_first_iters: int = 50,
     max_iters_used: int = 500,
-) -> "dict[str, Any] | None":
+) -> dict[str, Any] | None:
     """Return per-GPU throughput metrics for *log_path*, with CSV caching.
 
     Cache layout inside ``<run_dir>/throughput/`` (sibling of ``logs/``):
@@ -257,9 +267,9 @@ def load_or_compute_throughput(
     ``avg_tflop_per_gpu``, ``avg_tok_per_gpu``, ``avg_elapsed_ms``,
     or ``None`` if the log cannot be parsed.
     """
-    tp_dir  = _throughput_dir(log_path)
+    tp_dir = _throughput_dir(log_path)
     avg_csv = tp_dir / "avg_throughput.csv"
-    job_id  = _job_id_from_log(log_path)
+    job_id = _job_id_from_log(log_path)
 
     cached = _load_avg_row(avg_csv, job_id, max_elapsed_ms, skip_first_iters, max_iters_used)
     if cached is not None:
@@ -306,7 +316,8 @@ def gpu_count_from_path(
 
 
 def parse_sbatch(path: Path) -> tuple[int | None, int | None]:
-    """Return (nodes, gpus_per_node) from a SLURM sbatch file, or (None, None) if absent."""
+    """Return (nodes, gpus_per_node) from a SLURM sbatch file, or (None, None)
+    if absent."""
     if not path.is_file():
         return None, None
     text = path.read_text(errors="replace")

--- a/tools/progress_tracker.py
+++ b/tools/progress_tracker.py
@@ -5,16 +5,23 @@ Reads a sweep YAML config, discovers all expected runs under the results directo
 and prints a detailed per-Slurm-job table with training metrics, throughput, GPU
 hours, and status.
 
-Usage:
-    python progress_tracker.py <config.yaml> [options]
+Usage (run from repo root):
+    python tools/progress_tracker.py <config.yaml> [--machine LEO|MN5] [options]
 
-    # Override where to look for runs (useful when cluster paths differ from local mount):
-    python progress_tracker.py config/experiments/multilingual_scaling/0.1B_ne.yaml \\
-        --results-dir /home/diana/mn5/multilingual_scaling/0.1B_ne/training
+    # Basic — prints table to stdout:
+    python tools/progress_tracker.py config/experiments/<user>/<exp>/<model>.yaml --machine LEO
 
-    # Also write a CSV:
-    python progress_tracker.py config/experiments/multilingual_scaling/0.1B_ne.yaml \\
-        --csv status.csv
+    # Write markdown and CSV output files:
+    python tools/progress_tracker.py config/experiments/<user>/<exp>/<model>.yaml \\
+        --machine LEO --md /path/to/progress.md --csv /path/to/progress.csv
+
+    # Also measure checkpoint storage (slow on large trees):
+    python tools/progress_tracker.py config/experiments/<user>/<exp>/<model>.yaml \\
+        --machine LEO --compute-storage --md /path/to/progress.md --csv /path/to/progress.csv
+
+    # Override where to look for runs (useful when cluster paths differ):
+    python tools/progress_tracker.py config/experiments/<user>/<exp>/<model>.yaml \\
+        --results-dir /path/to/experiment/training
 """
 
 from __future__ import annotations

--- a/tools/progress_tracker.py
+++ b/tools/progress_tracker.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""
-Sweep run status table for multilingual_scaling experiments.
+"""Sweep run status table for multilingual_scaling experiments.
 
 Reads a sweep YAML config, discovers all expected runs under the results directory,
 and prints a detailed per-Slurm-job table with training metrics, throughput, GPU
@@ -43,14 +42,14 @@ for _d in (_tools_dir, _scripts_dir):
     if _d not in sys.path:
         sys.path.insert(0, _d)
 
-from gpu_hours import (
+from gpu_hours import (  # noqa: E402
     collect_job_ids as _gpu_collect_job_ids,
     query_sacct as _gpu_query_sacct,
     parse_elapsed as _gpu_parse_elapsed,
 )
-from low_throughput_analysis import analyze_job as _analyze_low_throughput_job
-from megatron_throughput_from_logs import load_or_compute_throughput as _compute_throughput
-from validate_sweep_runs import (
+from low_throughput_analysis import analyze_job as _analyze_low_throughput_job  # noqa: E402
+from megatron_throughput_from_logs import load_or_compute_throughput as _compute_throughput  # noqa: E402
+from validate_sweep_runs import (  # noqa: E402
     _resolve_defaults,
     render_job_name,
     substitute_omegaconf_path_vars as _subst,
@@ -63,22 +62,16 @@ from validate_sweep_runs import (
 RE_ARG = re.compile(r"\[default\d+\]:\s{2}(\w+)\s+\.+\s+(.+)")
 
 # Model parameter count lines
-RE_TOTAL_PARAMS_B = re.compile(
-    r"\[default0\]:Total number of parameters in billions:\s+([\d.]+)"
-)
+RE_TOTAL_PARAMS_B = re.compile(r"\[default0\]:Total number of parameters in billions:\s+([\d.]+)")
 RE_TRANSFORMER_PARAMS_B = re.compile(
     r"\[default0\]:Number of parameters in transformer block in billions:\s+([\d.]+)"
 )
 
 # Training loss from iteration lines: "lm loss: 3.1416"
-RE_TRAIN_LOSS = re.compile(
-    r"iteration\s+\d+/\s*\d+\s*\|[^\n]*lm loss:\s*([\d.eE+\-]+)"
-)
+RE_TRAIN_LOSS = re.compile(r"iteration\s+\d+/\s*\d+\s*\|[^\n]*lm loss:\s*([\d.eE+\-]+)")
 
 # Validation loss lines: "validation loss at iteration X | lm loss value: Y"
-RE_VAL_LOSS = re.compile(
-    r"validation loss at[^\n]*\|[^\n]*lm loss value:\s*([\d.eE+\-]+)"
-)
+RE_VAL_LOSS = re.compile(r"validation loss at[^\n]*\|[^\n]*lm loss value:\s*([\d.eE+\-]+)")
 
 # Throughput / iteration line
 RE_ITER = re.compile(
@@ -103,12 +96,8 @@ RE_OOM = re.compile(r"OutOfMemoryError|CUDA out of memory", re.IGNORECASE)
 RE_FATAL = re.compile(r"\bFATAL ERROR\b", re.IGNORECASE)
 RE_TIME_LIMIT = re.compile(r"DUE TO TIME LIMIT", re.IGNORECASE)
 RE_NODE_FAILURE = re.compile(r"DUE TO NODE FAILURE|Node failure on\b|NODE_FAIL", re.IGNORECASE)
-RE_SIGTERM = re.compile(
-    r"SignalException.*?sigval=Signals\.SIGTERM|signal: 15\b", re.IGNORECASE
-)
-RE_WANDB_SUMMARY = re.compile(
-    r"wandb:\s+Run summary:|wandb:\s+Synced\s+\S", re.IGNORECASE
-)
+RE_SIGTERM = re.compile(r"SignalException.*?sigval=Signals\.SIGTERM|signal: 15\b", re.IGNORECASE)
+RE_WANDB_SUMMARY = re.compile(r"wandb:\s+Run summary:|wandb:\s+Synced\s+\S", re.IGNORECASE)
 
 # SBATCH directives
 RE_SBATCH_NODES = re.compile(r"^#SBATCH\s+--nodes[= ](\d+)", re.MULTILINE)
@@ -143,13 +132,21 @@ def _summary_table_sort_key(
     exp_name: str,
     run_tier_map: dict[str, str],
     run_stage_map: dict[str, str],
-) -> tuple[int, int, str]:
+) -> tuple:
     tier = run_tier_map.get(exp_name, "")
     stage = run_stage_map.get(exp_name, "")
+    lr_m = re.search(r"_lr([0-9.e+\-]+)_", exp_name)
+    gbsz_m = re.search(r"_gbsz(\d+)_", exp_name)
+    tok_m = re.search(r"(?:stable|decay)(\d+)BT", exp_name)
+    lr = float(lr_m.group(1)) if lr_m else 0.0
+    gbsz = int(gbsz_m.group(1)) if gbsz_m else 0
+    tok = int(tok_m.group(1)) if tok_m else 0
     return (
         TIER_SORT_ORDER.get(tier, 99),
+        lr,
+        gbsz,
         0 if stage == "stable" else 1,
-        exp_name,
+        tok,
     )
 
 
@@ -183,15 +180,16 @@ def _build_summary_exp_gpu_h(
 # ── Monitor-state event classification ───────────────────────────────────────
 
 _CLEAN_RESTART_EVENTS = frozenset({"time_limit", "inactive"})
-_HARD_ERROR_EVENTS    = frozenset({"segmentation_fault", "error", "bus_error",
-                                    "nan_loss", "connection_failure"})
-_FINISH_EVENTS        = frozenset({"finished_training", "finish"})
+_HARD_ERROR_EVENTS = frozenset(
+    {"segmentation_fault", "error", "bus_error", "nan_loss", "connection_failure"}
+)
+_FINISH_EVENTS = frozenset({"finished_training", "finish"})
 
 _EVENT_ERROR_DESC: dict[str, str] = {
     "segmentation_fault": "Segmentation fault",
-    "error":              "Exit code 1",
-    "bus_error":          "Bus error",
-    "nan_loss":           "NaN loss",
+    "error": "Exit code 1",
+    "bus_error": "Bus error",
+    "nan_loss": "NaN loss",
     "connection_failure": "Connection failure",
 }
 
@@ -200,20 +198,21 @@ _EVENT_ERROR_DESC: dict[str, str] = {
 _EVENT_MATCH_TOLERANCE_S = 300.0
 
 
-
 def _eval_token_set(s: str) -> set[int]:
-    """Evaluate a Python set-literal string like '{6_000_000_000}' or 'set()' into a set of ints."""
+    """Evaluate a Python set-literal string like '{6_000_000_000}' or 'set()'
+    into a set of ints."""
     if not s:
         return set()
     try:
         result = eval(s)  # safe: these are only integer set literals from the YAML
-        return set(int(x) for x in result) if isinstance(result, (set, frozenset)) else set()
+        return {int(x) for x in result} if isinstance(result, (set, frozenset)) else set()
     except Exception:
         return set()
 
 
 def parse_config(config_path: str) -> dict:
-    """Parse sweep config and return all valid (run_name, stage, tokens) combos.
+    """Parse sweep config and return all valid (run_name, stage, tokens)
+    combos.
 
     The sweep uses a per-combo filter: each Group-1 entry carries
     center/cross/diagonal_tokens_set; a decay stage is only valid for a combo
@@ -238,7 +237,7 @@ def parse_config(config_path: str) -> dict:
     job_name_tpl: str | None = None
 
     # Pass 1 – collect per-combo data (Group 1 entries) and all decay stage defs (Group 2).
-    combos: list[dict] = []          # {lr, gbsz, stable_tokens, valid_decay_tokens: set[int]}
+    combos: list[dict] = []  # {lr, gbsz, stable_tokens, valid_decay_tokens: set[int]}
     all_decay_stages: OrderedDict[str, int] = OrderedDict()  # stage_name -> token_budget
 
     # Used by the "new format" where stable entries carry an explicit stage name (e.g.
@@ -270,29 +269,38 @@ def parse_config(config_path: str) -> dict:
                 gbsz = int(entry["backend.megatron.global_batch_size"])
                 stable_tok = int(entry.get("backend.megatron.aux.tokens", aux["tokens"]))
 
-                center = _eval_token_set(entry.get("backend.megatron.aux.center_tokens_set", "set()"))
+                center = _eval_token_set(
+                    entry.get("backend.megatron.aux.center_tokens_set", "set()")
+                )
                 cross = _eval_token_set(entry.get("backend.megatron.aux.cross_tokens_set", "set()"))
-                diagonal = _eval_token_set(entry.get("backend.megatron.aux.diagonal_tokens_set", "set()"))
+                diagonal = _eval_token_set(
+                    entry.get("backend.megatron.aux.diagonal_tokens_set", "set()")
+                )
                 valid_decay_tokens = center | cross | diagonal
 
-                combos.append({
-                    "lr": lr,
-                    "gbsz": gbsz,
-                    "stable_tokens": stable_tok,
-                    "valid_decay_tokens": valid_decay_tokens,
-                    "center_tokens": center,
-                    "cross_tokens": cross,
-                    "diagonal_tokens": diagonal,
-                    "stable_launch_tier": str(entry.get("backend.megatron.aux.stable_launch_tier", "")),
-                    "stable_stage_name": None,  # old format: use "stable" + job_horizon_suffix
-                })
+                combos.append(
+                    {
+                        "lr": lr,
+                        "gbsz": gbsz,
+                        "stable_tokens": stable_tok,
+                        "valid_decay_tokens": valid_decay_tokens,
+                        "center_tokens": center,
+                        "cross_tokens": cross,
+                        "diagonal_tokens": diagonal,
+                        "stable_launch_tier": str(
+                            entry.get("backend.megatron.aux.stable_launch_tier", "")
+                        ),
+                        "stable_stage_name": None,  # old format: use "stable" + job_horizon_suffix
+                    }
+                )
                 continue
 
             # New format: stable phase entry with an explicit stage name (e.g. "stable12BT").
             # The adjacent decay list (next type:list entry) provides valid_decay_tokens.
             _stage_val = entry.get("stage", "")
             if (
-                isinstance(_stage_val, str) and _stage_val.startswith("stable")
+                isinstance(_stage_val, str)
+                and _stage_val.startswith("stable")
                 and "backend.megatron.lr" in entry
                 and "backend.megatron.global_batch_size" in entry
                 and "backend.megatron.aux.tokens" in entry
@@ -306,7 +314,9 @@ def parse_config(config_path: str) -> dict:
                     "center_tokens": set(),
                     "cross_tokens": set(),
                     "diagonal_tokens": set(),
-                    "stable_launch_tier": str(entry.get("backend.megatron.aux.stable_launch_tier", "")),
+                    "stable_launch_tier": str(
+                        entry.get("backend.megatron.aux.stable_launch_tier", "")
+                    ),
                     "stable_stage_name": _stage_val,  # new format: pass full name (e.g. "stable12BT")
                 }
                 continue
@@ -320,7 +330,11 @@ def parse_config(config_path: str) -> dict:
             if entry.get("type") == "list" and "configs" in entry:
                 _decay_toks: set[int] = set()
                 for dc in entry["configs"]:
-                    if isinstance(dc, dict) and "stage" in dc and "backend.megatron.aux.tokens" in dc:
+                    if (
+                        isinstance(dc, dict)
+                        and "stage" in dc
+                        and "backend.megatron.aux.tokens" in dc
+                    ):
                         stage_name = str(dc["stage"])
                         tok = int(dc["backend.megatron.aux.tokens"])
                         all_decay_stages[stage_name] = tok
@@ -345,6 +359,7 @@ def parse_config(config_path: str) -> dict:
 
 # ── Checkpoint storage ─────────────────────────────────────────────────────────
 
+
 def _save_interval(gbsz: int) -> int:
     return _SAVE_INTERVAL_NUM // gbsz
 
@@ -356,14 +371,12 @@ def _train_iters(tokens: int, gbsz: int, seq_length: int) -> int:
 def _count_checkpoint_iters(checkpoints_dir: Path) -> int:
     if not checkpoints_dir.is_dir():
         return 0
-    return sum(
-        1 for p in checkpoints_dir.iterdir()
-        if p.is_dir() and p.name.startswith("iter_")
-    )
+    return sum(1 for p in checkpoints_dir.iterdir() if p.is_dir() and p.name.startswith("iter_"))
 
 
 def measure_checkpoint_storage_gb(checkpoints_dir: Path, *, timeout_s: int = 180) -> float | None:
-    """Return total checkpoint-directory size in GiB, or None if unavailable."""
+    """Return total checkpoint-directory size in GiB, or None if
+    unavailable."""
     if not checkpoints_dir.is_dir():
         return None
     try:
@@ -376,7 +389,7 @@ def measure_checkpoint_storage_gb(checkpoints_dir: Path, *, timeout_s: int = 180
         )
         if proc.returncode == 0 and proc.stdout.strip():
             nbytes = int(proc.stdout.split()[0])
-            return nbytes / (1024 ** 3)
+            return nbytes / (1024**3)
     except (OSError, ValueError, subprocess.TimeoutExpired):
         pass
     return None
@@ -438,12 +451,10 @@ def _expected_checkpoint_count(
     cooldown_decay_fraction: float,
 ) -> int:
     if _is_stable_stage(stage):
-        return len(_expected_stable_checkpoint_iters(
-            tokens, gbsz, seq_length, cooldown_decay_fraction
-        ))
-    return len(_expected_decay_checkpoint_iters(
-        tokens, gbsz, seq_length, cooldown_decay_fraction
-    ))
+        return len(
+            _expected_stable_checkpoint_iters(tokens, gbsz, seq_length, cooldown_decay_fraction)
+        )
+    return len(_expected_decay_checkpoint_iters(tokens, gbsz, seq_length, cooldown_decay_fraction))
 
 
 def measure_all_checkpoint_storage_gb(
@@ -452,7 +463,8 @@ def measure_all_checkpoint_storage_gb(
     *,
     max_workers: int = 8,
 ) -> dict[str, float | None]:
-    """Measure checkpoint storage for many runs in parallel (du -sb per run)."""
+    """Measure checkpoint storage for many runs in parallel (du -sb per
+    run)."""
     results: dict[str, float | None] = {}
 
     def _du_one(name: str) -> tuple[str, float | None]:
@@ -485,8 +497,7 @@ def build_run_checkpoint_storage(
     run_names = [name for name, _stage, _tok, _tier in run_specs]
     measured_gb = measure_all_checkpoint_storage_gb(resolved_base, run_names)
     iter_counts = {
-        name: _count_checkpoint_iters(resolved_base / name / "checkpoints")
-        for name in run_names
+        name: _count_checkpoint_iters(resolved_base / name / "checkpoints") for name in run_names
     }
 
     gb_per_ckpt_samples: list[float] = []
@@ -512,9 +523,7 @@ def build_run_checkpoint_storage(
         latest = next((r for r in reversed(rows) if r["run_name"] == run_name), None)
         status = latest.get("status_word", "") if latest else ""
 
-        measured_val: float | None = (
-            gb if gb is not None and gb > 0 and n_ckpt > 0 else None
-        )
+        measured_val: float | None = gb if gb is not None and gb > 0 and n_ckpt > 0 else None
 
         remaining_val: float | None = None
         gbsz = run_to_gbsz.get(run_name)
@@ -576,11 +585,12 @@ def _format_ckpt_gb_total(total: float, *, compute: bool, md: bool = False) -> s
 
 # ── SBATCH parsing ────────────────────────────────────────────────────────────
 
+
 def parse_sbatch(path: Path) -> tuple[int | None, int | None, int | None]:
     """Return (nodes, gpus_per_node, ckpt_step) from a job.sbatch file.
 
-    ckpt_step is the value of --ckpt-step, present only in decay jobs to indicate
-    the absolute iteration from which the decay phase starts.
+    ckpt_step is the value of --ckpt-step, present only in decay jobs to
+    indicate the absolute iteration from which the decay phase starts.
     """
     if not path.is_file():
         return None, None, None
@@ -604,11 +614,14 @@ def parse_sbatch(path: Path) -> tuple[int | None, int | None, int | None]:
 
 # ── Stdout log parsing ────────────────────────────────────────────────────────
 
-def parse_stdout(log_path: Path) -> dict:
-    """Parse a Megatron stdout log for training params, model size, and iteration tracking.
 
-    Throughput metrics (avg_tflop_per_gpu, avg_tok_per_gpu) are NOT computed here;
-    call load_or_compute_throughput() separately so caching is applied consistently.
+def parse_stdout(log_path: Path) -> dict:
+    """Parse a Megatron stdout log for training params, model size, and
+    iteration tracking.
+
+    Throughput metrics (avg_tflop_per_gpu, avg_tok_per_gpu) are NOT
+    computed here; call load_or_compute_throughput() separately so
+    caching is applied consistently.
     """
     result: dict[str, Any] = {
         "global_batch_size": None,
@@ -726,6 +739,7 @@ def parse_stdout(log_path: Path) -> dict:
 
 # ── Stderr log parsing ────────────────────────────────────────────────────────
 
+
 def parse_stderr(log_path: Path) -> dict:
     """Parse stderr log for error patterns and wandb completion signal."""
     result: dict[str, Any] = {
@@ -781,18 +795,26 @@ def _parse_sacct_ts(s: str) -> float | None:
 
 
 def query_sacct(job_ids: list[str]) -> dict[str, dict]:
-    """Query sacct for job state, elapsed time, GPU count, and start/end timestamps.
-    Returns {} on error."""
+    """Query sacct for job state, elapsed time, GPU count, and start/end
+    timestamps.
+
+    Returns {} on error.
+    """
     if not job_ids:
         return {}
     try:
         result = subprocess.run(
             [
-                "sacct", "-j", ",".join(job_ids),
+                "sacct",
+                "-j",
+                ",".join(job_ids),
                 "--format=JobID,State,Elapsed,AllocTRES%80,Start,End,User",
-                "--noheader", "--parsable2",
+                "--noheader",
+                "--parsable2",
             ],
-            capture_output=True, text=True, timeout=15,
+            capture_output=True,
+            text=True,
+            timeout=15,
         )
         if result.returncode != 0:
             return {}
@@ -813,13 +835,13 @@ def query_sacct(job_ids: list[str]) -> dict[str, dict]:
         if m:
             gpus = int(m.group(1))
         info[jid_field.strip()] = {
-            "state":    state.strip(),
-            "elapsed":  elapsed.strip(),
-            "gpus":     gpus,
+            "state": state.strip(),
+            "elapsed": elapsed.strip(),
+            "gpus": gpus,
             "start_ts": _parse_sacct_ts(start),
-            "end_ts":   _parse_sacct_ts(end),
+            "end_ts": _parse_sacct_ts(end),
             "start_str": start.strip(),
-            "user":     user,
+            "user": user,
         }
     return info
 
@@ -840,7 +862,8 @@ def gpu_hours_from_timestamps(
 
 
 def load_external_gpu_h(csv_path: str) -> dict[tuple[str, str], float]:
-    """Load per-job GPU-h from a CSV previously produced by this script (--csv output).
+    """Load per-job GPU-h from a CSV previously produced by this script (--csv
+    output).
 
     Expects at minimum columns: Run, JobID, GPU-h.
     Returns {(run_name, job_id): gpu_hours}.  Rows with blank JobID are skipped.
@@ -850,8 +873,8 @@ def load_external_gpu_h(csv_path: str) -> dict[tuple[str, str], float]:
         reader = csv.DictReader(f)
         for row in reader:
             run_name = row.get("Run", "").strip()
-            job_id   = row.get("JobID", "").strip()
-            gpu_h_s  = row.get("GPU-h", "").strip()
+            job_id = row.get("JobID", "").strip()
+            gpu_h_s = row.get("GPU-h", "").strip()
             if not run_name or not job_id or not gpu_h_s:
                 continue
             try:
@@ -862,6 +885,7 @@ def load_external_gpu_h(csv_path: str) -> dict[tuple[str, str], float]:
 
 
 # ── Job discovery ─────────────────────────────────────────────────────────────
+
 
 def _run_id_sets(run_dir: Path) -> tuple[set[str], set[str]]:
     """Return (config_ids, log_ids) for a run directory.
@@ -897,17 +921,20 @@ def _run_id_sets(run_dir: Path) -> tuple[set[str], set[str]]:
 
 
 def find_job_ids(run_dir: Path) -> list[str]:
-    """Return all Slurm job IDs found in logs/ or config-*.yaml files, sorted ascending.
+    """Return all Slurm job IDs found in logs/ or config-*.yaml files, sorted
+    ascending.
 
-    config-{id}.yaml is written at submission time; stdout/stderr logs only appear
-    once the job starts. Including config-based IDs lets us detect jobs that are
-    submitted (or queued) but haven't started writing logs yet.
+    config-{id}.yaml is written at submission time; stdout/stderr logs
+    only appear once the job starts. Including config-based IDs lets us
+    detect jobs that are submitted (or queued) but haven't started
+    writing logs yet.
     """
     config_ids, log_ids = _run_id_sets(run_dir)
     return sorted(config_ids | log_ids)
 
 
 # ── Token budget from run name ─────────────────────────────────────────────────
+
 
 def extract_token_budget(run_name: str) -> str:
     m = RE_BUDGET.search(run_name)
@@ -917,6 +944,7 @@ def extract_token_budget(run_name: str) -> str:
 
 
 # ── Monitor-state loading ─────────────────────────────────────────────────────
+
 
 def load_run_monitor_events(run_name: str, monitor_dirs: list[Path]) -> list[dict] | None:
     """Load all monitor-state sessions for *run_name* from *monitor_dirs*.
@@ -940,17 +968,21 @@ def load_run_monitor_events(run_name: str, monitor_dirs: list[Path]) -> list[dic
                 parts = key.split(":")
                 # key format: "log:<event_name>:<log_events_index>"
                 if len(parts) >= 2 and parts[0] == "log":
-                    events.append({
-                        "name": parts[1],
-                        "ts":   val.get("last_action_ts"),
-                    })
-            sessions.append({
-                "session_id":     d.name,
-                "events":         events,
-                "last_status":    rt.get("last_status"),
-                "final_state":    rt.get("final_state"),
-                "runtime_job_id": rt.get("runtime_job_id"),
-            })
+                    events.append(
+                        {
+                            "name": parts[1],
+                            "ts": val.get("last_action_ts"),
+                        }
+                    )
+            sessions.append(
+                {
+                    "session_id": d.name,
+                    "events": events,
+                    "last_status": rt.get("last_status"),
+                    "final_state": rt.get("final_state"),
+                    "runtime_job_id": rt.get("runtime_job_id"),
+                }
+            )
     return sessions if sessions else None
 
 
@@ -959,7 +991,8 @@ def map_events_to_jobs(
     sacct_info: dict[str, dict],
     monitor_sessions: list[dict],
 ) -> dict[str, set[str]]:
-    """Assign monitor-state events to specific Slurm job IDs via sacct timestamps.
+    """Assign monitor-state events to specific Slurm job IDs via sacct
+    timestamps.
 
     For each event's ``last_action_ts``, we find the job whose sacct time window
     [Start, End + _EVENT_MATCH_TOLERANCE_S] contains the timestamp.
@@ -970,10 +1003,7 @@ def map_events_to_jobs(
     job_events: dict[str, set[str]] = {jid: set() for jid in job_ids}
 
     all_events = [
-        ev
-        for session in monitor_sessions
-        for ev in session["events"]
-        if ev.get("ts") is not None
+        ev for session in monitor_sessions for ev in session["events"] if ev.get("ts") is not None
     ]
     if not all_events:
         return job_events
@@ -981,7 +1011,7 @@ def map_events_to_jobs(
     for job_id in job_ids:
         sacct = sacct_info.get(job_id, {})
         start_ts = sacct.get("start_ts")
-        end_ts   = sacct.get("end_ts")
+        end_ts = sacct.get("end_ts")
         if start_ts is None:
             continue
         deadline = (end_ts if end_ts is not None else float("inf")) + _EVENT_MATCH_TOLERANCE_S
@@ -994,6 +1024,7 @@ def map_events_to_jobs(
 
 # ── Status determination ──────────────────────────────────────────────────────
 
+
 def _compute_restart_action(
     job_id: str,
     job_has_config: bool,
@@ -1002,7 +1033,8 @@ def _compute_restart_action(
     run_config_ids: set[str],
     run_log_ids: set[str],
 ) -> str:
-    """Return the restart action for a failed/cancelled job based on what followed it.
+    """Return the restart action for a failed/cancelled job based on what
+    followed it.
 
     Looks at the next job in sequence that actually ran (has logs) and classifies:
       AUTO_RESTARTED:    next running job has a config  (normal autoexp restart)
@@ -1022,7 +1054,7 @@ def _compute_restart_action(
         return "NONE"
     # Find the next job that actually ran (has a log file)
     next_running: str | None = None
-    for later_id in all_job_ids[idx + 1:]:
+    for later_id in all_job_ids[idx + 1 :]:
         if later_id in run_log_ids:
             next_running = later_id
             break
@@ -1045,8 +1077,7 @@ def determine_status(
     run_config_ids: set[str] | None = None,
     run_log_ids: set[str] | None = None,
 ) -> tuple[str, str, str, str]:
-    """
-    Returns (emoji, status_word, error_description, action_word).
+    """Returns (emoji, status_word, error_description, action_word).
 
     Status words:  NOT_LAUNCHED | QUEUED | DONE | FAILED | CANCELLED | TRAINING
     Action words:  AUTO_RESTARTED | MANUALLY_RESTARTED | NEW_SESSION | NONE | ""
@@ -1065,29 +1096,29 @@ def determine_status(
     sacct_state = sacct.get("state", "")
 
     # Pre-compute restart action (used for all FAILED/CANCELLED paths below)
-    _cfg_ids  = run_config_ids if run_config_ids is not None else set()
-    _log_ids  = run_log_ids    if run_log_ids    is not None else set()
-    _has_cfg  = job_id in _cfg_ids
-    _restart  = _compute_restart_action(job_id, _has_cfg, is_latest_job, all_job_ids, _cfg_ids, _log_ids)
+    _cfg_ids = run_config_ids if run_config_ids is not None else set()
+    _log_ids = run_log_ids if run_log_ids is not None else set()
+    _has_cfg = job_id in _cfg_ids
+    _restart = _compute_restart_action(
+        job_id, _has_cfg, is_latest_job, all_job_ids, _cfg_ids, _log_ids
+    )
 
     # ── Classify events from monitor state (primary) or stderr (fallback) ────
     use_monitor = job_monitor_events is not None
     if use_monitor:
-        triggered_hard  = job_monitor_events & _HARD_ERROR_EVENTS
+        triggered_hard = job_monitor_events & _HARD_ERROR_EVENTS
         triggered_clean = job_monitor_events & _CLEAN_RESTART_EVENTS
-        triggered_done  = job_monitor_events & _FINISH_EVENTS
-        hard_error_desc = "; ".join(
-            _EVENT_ERROR_DESC.get(n, n) for n in sorted(triggered_hard)
-        )
+        triggered_done = job_monitor_events & _FINISH_EVENTS
+        hard_error_desc = "; ".join(_EVENT_ERROR_DESC.get(n, n) for n in sorted(triggered_hard))
     else:
         # stderr-derived booleans (legacy path)
-        triggered_hard  = set()
+        triggered_hard = set()
         triggered_clean = set()
-        triggered_done  = set()
+        triggered_done = set()
         hard_error_desc = ""
 
     # ── DONE ─────────────────────────────────────────────────────────────────
-    last_iter   = stdout_data.get("last_iter")
+    last_iter = stdout_data.get("last_iter")
     train_iters = stdout_data.get("train_iters")
     if last_iter is not None and train_iters is not None and last_iter >= train_iters:
         return "✅", "DONE", "", ""
@@ -1150,7 +1181,9 @@ def determine_status(
     return "⚠️", "FAILED", error_str, _restart
 
 
-def compute_progress(last_iter: int | None, ckpt_step: int | None, total_iters: int | None) -> float | None:
+def compute_progress(
+    last_iter: int | None, ckpt_step: int | None, total_iters: int | None
+) -> float | None:
     """Return training progress [0–100] for a single training phase.
 
     ckpt_step is the absolute iteration where training started (0 for stable runs,
@@ -1169,6 +1202,7 @@ def compute_progress(last_iter: int | None, ckpt_step: int | None, total_iters: 
 
 
 # ── Main ──────────────────────────────────────────────────────────────────────
+
 
 def main() -> None:
     ap = argparse.ArgumentParser(
@@ -1239,8 +1273,8 @@ def main() -> None:
         "--machine",
         default="LEO",
         help="Local cluster name tag (e.g. LEO, MN5). Jobs on this cluster are tagged "
-             "using this value; foreign-cluster jobs detected via sacct collision are "
-             "tagged with the opposite name. Default: %(default)s",
+        "using this value; foreign-cluster jobs detected via sacct collision are "
+        "tagged with the opposite name. Default: %(default)s",
     )
     args = ap.parse_args()
 
@@ -1251,8 +1285,7 @@ def main() -> None:
     if args.monitor_dirs is None:
         monitor_root = project_root / "monitor_state"
         monitor_dirs: list[Path] = (
-            sorted(p for p in monitor_root.iterdir() if p.is_dir())
-            if monitor_root.is_dir() else []
+            sorted(p for p in monitor_root.iterdir() if p.is_dir()) if monitor_root.is_dir() else []
         )
     else:
         monitor_dirs = [Path(d) for d in args.monitor_dirs]
@@ -1265,10 +1298,12 @@ def main() -> None:
     adam_beta2 = cfg.get("adam_beta2", 0.95)
 
     def _render(stage: str, lr: float, gbsz: int, stable_tok: int | None = None) -> str:
-        """render_job_name wrapper that also substitutes adam_beta2 and similar extras.
+        """render_job_name wrapper that also substitutes adam_beta2 and similar
+        extras.
 
-        render_job_name leaves un-substituted keys as '\\${key}' (backslash kept),
-        so we must match the same prefix when replacing.
+        render_job_name leaves un-substituted keys as '\\${key}'
+        (backslash kept), so we must match the same prefix when
+        replacing.
         """
         raw = render_job_name(cfg["job_name_tpl"], 1, lr, gbsz, seed, stage, stable_tok)
         return raw.replace("\\${backend.megatron.adam_beta2}", str(adam_beta2))
@@ -1295,7 +1330,9 @@ def main() -> None:
 
         # New format: stable_stage_name is the full name (e.g. "stable12BT"); old format: None.
         stable_stage = combo.get("stable_stage_name") or "stable"
-        stable_name = _render(stable_stage, lr, gbsz, stable_tok if stable_stage == "stable" else None)
+        stable_name = _render(
+            stable_stage, lr, gbsz, stable_tok if stable_stage == "stable" else None
+        )
         run_specs.append((stable_name, "stable", stable_tok, combo["stable_launch_tier"]))
         run_to_gbsz[stable_name] = gbsz
 
@@ -1321,11 +1358,13 @@ def main() -> None:
     # Resolve the local results base directory (template typically has no per-combo vars here)
     sample_ctx: dict[str, Any] = {"backend.megatron.seed": seed}
     if combos:
-        sample_ctx.update({
-            "backend.megatron.global_batch_size": combos[0]["gbsz"],
-            "backend.megatron.num_experts": 1,
-            "backend.megatron.lr": combos[0]["lr"],
-        })
+        sample_ctx.update(
+            {
+                "backend.megatron.global_batch_size": combos[0]["gbsz"],
+                "backend.megatron.num_experts": 1,
+                "backend.megatron.lr": combos[0]["lr"],
+            }
+        )
     resolved_base = Path(_subst(local_template, sample_ctx))
     if not resolved_base.is_dir():
         resolved_base = Path(local_template)
@@ -1340,14 +1379,15 @@ def main() -> None:
         all_job_ids.extend(jids)
 
     sacct_info = query_sacct(all_job_ids)
-    sacct_available = bool(sacct_info) or bool(all_job_ids)  # mark as available if sacct returned anything
 
     # If sacct is unavailable and --csv points to an existing file, read back the
     # GPU-h column from that file so the values are preserved when it is rewritten.
     external_job_gpu_h: dict[tuple[str, str], float] = {}
     if not sacct_info and args.csv and Path(args.csv).is_file():
         external_job_gpu_h = load_external_gpu_h(args.csv)
-        print(f"sacct unavailable – loaded {len(external_job_gpu_h)} per-job GPU-h entries from {args.csv}")
+        print(
+            f"sacct unavailable – loaded {len(external_job_gpu_h)} per-job GPU-h entries from {args.csv}"
+        )
 
     # Load monitor-state events for every run and map them to Slurm job IDs.
     # run_monitor_sessions[run_name] = None  → no monitor state (use stderr fallback)
@@ -1393,53 +1433,64 @@ def main() -> None:
 
         if not job_ids:
             if run_dir.is_dir():
-                # Directory exists but no log files → submitted to Slurm, not started yet
-                s_emoji, s_word = "🕒", "QUEUED"
+                # Check monitor session: if every session for this run ended as cancelled,
+                # show CANCELLED rather than misleading the user into thinking it's queued.
+                _sessions = run_monitor_sessions.get(run_name) or []
+                _all_cancelled = bool(_sessions) and all(
+                    s.get("final_state") == "cancelled" for s in _sessions
+                )
+                if _all_cancelled:
+                    s_emoji, s_word = "🚫", "CANCELLED"
+                else:
+                    # Directory exists but no log files → submitted to Slurm, not started yet
+                    s_emoji, s_word = "🕒", "QUEUED"
             else:
                 # Run directory doesn't exist → this tier has not been launched at all
                 s_emoji, s_word = "⚪", "NOT_LAUNCHED"
-            rows.append({
-                "run_name": run_name,
-                "job_id": "",
-                "stage": stage,
-                "tier": tier,
-                "token_budget": token_budget,
-                "tokens_b": tokens / 1e9,
-                "nodes": sbatch_nodes,
-                "transformer_params_b": None,
-                "total_params_b": None,
-                "global_batch_size": None,
-                "lr": None,
-                "micro_batch_size": None,
-                "num_workers": None,
-                "ttfi_min": None,
-                "ttfi_gpu_h": None,
-                "train_iters": None,
-                "last_iter": None,
-                "ckpt_step": sbatch_ckpt_step,
-                "progress": None,
-                "last_train_loss": None,
-                "last_val_loss": None,
-                "last_ckpt": last_ckpt,
-                "avg_tflop_per_gpu": None,
-                "avg_tok_per_gpu": None,
-                "n_iters_sampled": None,
-                "gpu_hours": None,
-                "time_lost_h": None,
-                "gpu_h_lost": None,
-                "overhead_time_h": None,
-                "overhead_gpu_h": None,
-                "overhead_pct": None,
-                "sacct_state": "",
-                "sacct_elapsed": "",
-                "sacct_start_str": "",
-                "owner": "",
-                "cluster": "",
-                "status_emoji": s_emoji,
-                "status_word": s_word,
-                "action_word": "",
-                "error_desc": "",
-            })
+            rows.append(
+                {
+                    "run_name": run_name,
+                    "job_id": "",
+                    "stage": stage,
+                    "tier": tier,
+                    "token_budget": token_budget,
+                    "tokens_b": tokens / 1e9,
+                    "nodes": sbatch_nodes,
+                    "transformer_params_b": None,
+                    "total_params_b": None,
+                    "global_batch_size": None,
+                    "lr": None,
+                    "micro_batch_size": None,
+                    "num_workers": None,
+                    "ttfi_min": None,
+                    "ttfi_gpu_h": None,
+                    "train_iters": None,
+                    "last_iter": None,
+                    "ckpt_step": sbatch_ckpt_step,
+                    "progress": None,
+                    "last_train_loss": None,
+                    "last_val_loss": None,
+                    "last_ckpt": last_ckpt,
+                    "avg_tflop_per_gpu": None,
+                    "avg_tok_per_gpu": None,
+                    "n_iters_sampled": None,
+                    "gpu_hours": None,
+                    "time_lost_h": None,
+                    "gpu_h_lost": None,
+                    "overhead_time_h": None,
+                    "overhead_gpu_h": None,
+                    "overhead_pct": None,
+                    "sacct_state": "",
+                    "sacct_elapsed": "",
+                    "sacct_start_str": "",
+                    "owner": "",
+                    "cluster": "",
+                    "status_emoji": s_emoji,
+                    "status_word": s_word,
+                    "action_word": "",
+                    "error_desc": "",
+                }
+            )
             continue
 
         for job_id in job_ids:
@@ -1498,7 +1549,7 @@ def main() -> None:
             #   2. sacct reports GPUs but fewer than half of what sbatch declares →
             #      a different user's small job collided (e.g. 1 GPU vs expected 32)
             _sacct_gpus = sacct_entry.get("gpus", 0)
-            _is_collision = (
+            _is_collision = bool(sacct_elapsed) and (
                 (sacct_entry and _sacct_gpus == 0 and total_gpus > 0)
                 or (sacct_entry and total_gpus > 0 and 0 < _sacct_gpus < total_gpus // 2)
             )
@@ -1535,9 +1586,7 @@ def main() -> None:
             # Validate first_iter_ts against the sacct time window: if the log
             # timestamp falls outside [start-60s, end+300s] the log was written by
             # a different job (stale filename or cross-cluster log mismatch).
-            if (first_iter_ts is not None
-                    and sacct_start is not None
-                    and sacct_end is not None):
+            if first_iter_ts is not None and sacct_start is not None and sacct_end is not None:
                 _ts = first_iter_ts.timestamp()
                 if _ts < sacct_start - 60 or _ts > sacct_end + 300:
                     first_iter_ts = None
@@ -1548,9 +1597,7 @@ def main() -> None:
             elif first_iter_ts is None and gpu_hours is not None and total_gpus > 0:
                 ttfi_min = (gpu_hours / total_gpus) * 60.0
             ttfi_gpu_h: float | None = (
-                (ttfi_min / 60.0) * total_gpus
-                if ttfi_min is not None and total_gpus > 0
-                else None
+                (ttfi_min / 60.0) * total_gpus if ttfi_min is not None and total_gpus > 0 else None
             )
 
             # Sanity check: TTFI cannot physically exceed total job elapsed time.
@@ -1561,37 +1608,45 @@ def main() -> None:
                 ttfi_gpu_h = None
 
             # Total overhead = TTFI + low-throughput (both in hours / GPU-h)
-            _lt_time_v  = _job_lt.get("time_lost_h")
+            _lt_time_v = _job_lt.get("time_lost_h")
             _lt_gpu_h_v = _job_lt.get("gpu_h_lost")
             overhead_time_h: float | None = (
                 (ttfi_min / 60.0 if ttfi_min is not None else 0.0) + (_lt_time_v or 0.0)
-                if ttfi_min is not None or _lt_time_v is not None else None
+                if ttfi_min is not None or _lt_time_v is not None
+                else None
             )
             overhead_gpu_h: float | None = (
                 (ttfi_gpu_h or 0.0) + (_lt_gpu_h_v or 0.0)
-                if ttfi_gpu_h is not None or _lt_gpu_h_v is not None else None
+                if ttfi_gpu_h is not None or _lt_gpu_h_v is not None
+                else None
             )
             # Sanity check: overhead cannot exceed total job GPU-h.  If it does,
             # the LowTP analysis read a longer log than the actual job duration
             # (cross-cluster log collision, same job ID sharing a log file).
             if overhead_gpu_h is not None and gpu_hours is not None and overhead_gpu_h > gpu_hours:
                 overhead_time_h = None
-                overhead_gpu_h  = None
+                overhead_gpu_h = None
             overhead_pct: float | None = (
                 overhead_gpu_h / gpu_hours * 100.0
-                if overhead_gpu_h is not None and gpu_hours and gpu_hours > 0 else None
+                if overhead_gpu_h is not None and gpu_hours and gpu_hours > 0
+                else None
             )
 
             # Per-job monitor events: set[str] if monitor state exists, else None
             job_events_map = run_job_monitor_events.get(run_name)
             job_monitor_events = (
-                job_events_map.get(job_id)   # may be empty set
+                job_events_map.get(job_id)  # may be empty set
                 if job_events_map is not None
-                else None                     # no monitor state → use stderr
+                else None  # no monitor state → use stderr
             )
 
             emoji, status_word, error_desc, action_word = determine_status(
-                job_id, job_ids, stdout_data, stderr_data, sacct_info, is_latest,
+                job_id,
+                job_ids,
+                stdout_data,
+                stderr_data,
+                sacct_info,
+                is_latest,
                 job_monitor_events=job_monitor_events,
                 run_config_ids=run_config_ids,
                 run_log_ids=run_log_ids,
@@ -1605,58 +1660,67 @@ def main() -> None:
             if _progress is not None and _progress >= 100.0 and status_word != "DONE":
                 emoji, status_word, error_desc, action_word = "✅", "DONE", "", ""
 
-            rows.append({
-                "run_name": run_name,
-                "job_id": job_id,
-                "stage": stage,
-                "token_budget": token_budget,
-                "tokens_b": tokens / 1e9,
-                "tier": tier,
-                "nodes": sbatch_nodes,
-                "transformer_params_b": stdout_data.get("transformer_params_b"),
-                "total_params_b": stdout_data.get("total_params_b"),
-                "global_batch_size": stdout_data.get("global_batch_size"),
-                "lr": stdout_data.get("lr"),
-                "micro_batch_size": stdout_data.get("micro_batch_size"),
-                "num_workers": stdout_data.get("num_workers"),
-                "ttfi_min": ttfi_min,
-                "ttfi_gpu_h": ttfi_gpu_h,
-                "train_iters": stdout_data.get("train_iters"),
-                "last_iter": stdout_data.get("last_iter"),
-                "ckpt_step": sbatch_ckpt_step,
-                "progress": _progress,
-                "last_train_loss": stdout_data.get("last_train_loss"),
-                "last_val_loss": stdout_data.get("last_val_loss"),
-                "last_ckpt": last_ckpt,
-                "avg_tflop_per_gpu": _tp["avg_tflop_per_gpu"] if _tp else None,
-                "avg_tok_per_gpu": _tp["avg_tok_per_gpu"] if _tp else None,
-                "n_iters_sampled": _tp["n_iters"] if _tp else None,
-                "gpu_hours": gpu_hours,
-                "time_lost_h": _job_lt.get("time_lost_h"),
-                "gpu_h_lost": _job_lt.get("gpu_h_lost"),
-                "overhead_time_h": overhead_time_h,
-                "overhead_gpu_h": overhead_gpu_h,
-                "overhead_pct": overhead_pct,
-                "sacct_state": sacct_state,
-                "sacct_elapsed": sacct_elapsed,
-                "sacct_start_str": sacct_entry.get("start_str", ""),
-                # sacct user for local jobs; fall back to path-based inference
-                # from log for foreign-cluster jobs (sacct entry is discarded).
-                "owner": sacct_entry.get("user", "") or stdout_data.get("log_user", "") or "",
-                "cluster": cluster,
-                "status_emoji": emoji,
-                "status_word": status_word,
-                "action_word": action_word,
-                "error_desc": error_desc,
-            })
+            rows.append(
+                {
+                    "run_name": run_name,
+                    "job_id": job_id,
+                    "stage": stage,
+                    "token_budget": token_budget,
+                    "tokens_b": tokens / 1e9,
+                    "tier": tier,
+                    "nodes": sbatch_nodes,
+                    "transformer_params_b": stdout_data.get("transformer_params_b"),
+                    "total_params_b": stdout_data.get("total_params_b"),
+                    "global_batch_size": stdout_data.get("global_batch_size"),
+                    "lr": stdout_data.get("lr"),
+                    "micro_batch_size": stdout_data.get("micro_batch_size"),
+                    "num_workers": stdout_data.get("num_workers"),
+                    "ttfi_min": ttfi_min,
+                    "ttfi_gpu_h": ttfi_gpu_h,
+                    "train_iters": stdout_data.get("train_iters"),
+                    "last_iter": stdout_data.get("last_iter"),
+                    "ckpt_step": sbatch_ckpt_step,
+                    "progress": _progress,
+                    "last_train_loss": stdout_data.get("last_train_loss"),
+                    "last_val_loss": stdout_data.get("last_val_loss"),
+                    "last_ckpt": last_ckpt,
+                    "avg_tflop_per_gpu": _tp["avg_tflop_per_gpu"] if _tp else None,
+                    "avg_tok_per_gpu": _tp["avg_tok_per_gpu"] if _tp else None,
+                    "n_iters_sampled": _tp["n_iters"] if _tp else None,
+                    "gpu_hours": gpu_hours,
+                    "time_lost_h": _job_lt.get("time_lost_h"),
+                    "gpu_h_lost": _job_lt.get("gpu_h_lost"),
+                    "overhead_time_h": overhead_time_h,
+                    "overhead_gpu_h": overhead_gpu_h,
+                    "overhead_pct": overhead_pct,
+                    "sacct_state": sacct_state,
+                    "sacct_elapsed": sacct_elapsed,
+                    "sacct_start_str": sacct_entry.get("start_str", ""),
+                    # sacct user for local jobs; fall back to path-based inference
+                    # from log for foreign-cluster jobs (sacct entry is discarded).
+                    "owner": sacct_entry.get("user", "") or stdout_data.get("log_user", "") or "",
+                    "cluster": cluster,
+                    "status_emoji": emoji,
+                    "status_word": status_word,
+                    "action_word": action_word,
+                    "error_desc": error_desc,
+                }
+            )
 
     # ── Fill-forward static fields for eval-only runs ───────────────────────
     # Fields that are constant per run but may be absent from an eval-only log
     # (Megatron may not print the full args/param-count block in eval mode).
     _FILL_FIELDS = [
-        "transformer_params_b", "total_params_b", "global_batch_size", "lr",
-        "micro_batch_size", "num_workers", "train_iters",
-        "avg_tflop_per_gpu", "avg_tok_per_gpu", "last_train_loss",
+        "transformer_params_b",
+        "total_params_b",
+        "global_batch_size",
+        "lr",
+        "micro_batch_size",
+        "num_workers",
+        "train_iters",
+        "avg_tflop_per_gpu",
+        "avg_tok_per_gpu",
+        "last_train_loss",
     ]
     _run_last_known: dict[str, dict[str, Any]] = {}
     for r in rows:
@@ -1758,17 +1822,17 @@ def main() -> None:
 
     _RESTART_ACTIONS = {"AUTO_RESTARTED", "MANUALLY_RESTARTED", "NEW_SESSION"}
     status_colors = {
-        "DONE":                           "\033[92m",
-        "TRAINING":                       "\033[94m",
-        "FAILED":                         "\033[91m",
-        "FAILED+AUTO_RESTARTED":          "\033[33m",
-        "FAILED+MANUALLY_RESTARTED":      "\033[35m",
-        "FAILED+NEW_SESSION":             "\033[36m",
-        "CANCELLED":                      "\033[91m",
-        "CANCELLED+MANUALLY_RESTARTED":   "\033[35m",
-        "CANCELLED+NEW_SESSION":          "\033[36m",
-        "QUEUED":                         "\033[93m",
-        "NOT_LAUNCHED":                   "\033[90m",
+        "DONE": "\033[92m",
+        "TRAINING": "\033[94m",
+        "FAILED": "\033[91m",
+        "FAILED+AUTO_RESTARTED": "\033[33m",
+        "FAILED+MANUALLY_RESTARTED": "\033[35m",
+        "FAILED+NEW_SESSION": "\033[36m",
+        "CANCELLED": "\033[91m",
+        "CANCELLED+MANUALLY_RESTARTED": "\033[35m",
+        "CANCELLED+NEW_SESSION": "\033[36m",
+        "QUEUED": "\033[93m",
+        "NOT_LAUNCHED": "\033[90m",
     }
     RESET = "\033[0m"
 
@@ -1785,28 +1849,36 @@ def main() -> None:
             color_key = r["status_word"]
         color = status_colors.get(color_key, "")
 
-        tflop_str    = f"{r['avg_tflop_per_gpu']:.1f}" if r["avg_tflop_per_gpu"] is not None else "N/A"
-        tok_str      = f"{r['avg_tok_per_gpu']:.0f}"  if r["avg_tok_per_gpu"]   is not None else "N/A"
-        gpu_h_str    = f"{r['gpu_hours']:.1f}"        if r["gpu_hours"]         is not None else "N/A"
-        lt_time_str  = f"{r['time_lost_h']:.3f}"      if r.get("time_lost_h")   is not None else "N/A"
-        lt_gpu_h_str = f"{r['gpu_h_lost']:.2f}"       if r.get("gpu_h_lost")    is not None else "N/A"
-        trans_str = f"{r['transformer_params_b']:.2f}" if r["transformer_params_b"] is not None else "N/A"
+        tflop_str = f"{r['avg_tflop_per_gpu']:.1f}" if r["avg_tflop_per_gpu"] is not None else "N/A"
+        tok_str = f"{r['avg_tok_per_gpu']:.0f}" if r["avg_tok_per_gpu"] is not None else "N/A"
+        gpu_h_str = f"{r['gpu_hours']:.1f}" if r["gpu_hours"] is not None else "N/A"
+        lt_time_str = f"{r['time_lost_h']:.3f}" if r.get("time_lost_h") is not None else "N/A"
+        lt_gpu_h_str = f"{r['gpu_h_lost']:.2f}" if r.get("gpu_h_lost") is not None else "N/A"
+        trans_str = (
+            f"{r['transformer_params_b']:.2f}" if r["transformer_params_b"] is not None else "N/A"
+        )
         total_str = f"{r['total_params_b']:.2f}" if r["total_params_b"] is not None else "N/A"
         lr_str = f"{r['lr']:.4f}" if r["lr"] is not None else "N/A"
         ckpt_str = str(r["last_ckpt"]) if r["last_ckpt"] is not None else "N/A"
         ti_str = str(r["train_iters"]) if r["train_iters"] is not None else "N/A"
         ci_str = str(r["last_iter"]) if r.get("last_iter") is not None else "N/A"
         prog_str = f"{r['progress']:.1f}%" if r.get("progress") is not None else "N/A"
-        trn_loss_str = f"{r['last_train_loss']:.4f}" if r.get("last_train_loss") is not None else "N/A"
+        trn_loss_str = (
+            f"{r['last_train_loss']:.4f}" if r.get("last_train_loss") is not None else "N/A"
+        )
         val_loss_str = f"{r['last_val_loss']:.4f}" if r.get("last_val_loss") is not None else "N/A"
         gbs_str = str(r["global_batch_size"]) if r["global_batch_size"] is not None else "N/A"
         mbs_str = str(r["micro_batch_size"]) if r["micro_batch_size"] is not None else "N/A"
         wkr_str = str(r["num_workers"]) if r["num_workers"] is not None else "N/A"
-        ttfi_str       = f"{r['ttfi_min']:.1f}"       if r.get("ttfi_min")       is not None else "N/A"
-        ttfi_gpu_h_str = f"{r['ttfi_gpu_h']:.2f}"    if r.get("ttfi_gpu_h")    is not None else "N/A"
-        oh_time_str    = f"{r['overhead_time_h']:.3f}" if r.get("overhead_time_h") is not None else "N/A"
-        oh_gpu_h_str   = f"{r['overhead_gpu_h']:.2f}" if r.get("overhead_gpu_h") is not None else "N/A"
-        oh_pct_str     = f"{r['overhead_pct']:.1f}%"  if r.get("overhead_pct")  is not None else "N/A"
+        ttfi_str = f"{r['ttfi_min']:.1f}" if r.get("ttfi_min") is not None else "N/A"
+        ttfi_gpu_h_str = f"{r['ttfi_gpu_h']:.2f}" if r.get("ttfi_gpu_h") is not None else "N/A"
+        oh_time_str = (
+            f"{r['overhead_time_h']:.3f}" if r.get("overhead_time_h") is not None else "N/A"
+        )
+        oh_gpu_h_str = (
+            f"{r['overhead_gpu_h']:.2f}" if r.get("overhead_gpu_h") is not None else "N/A"
+        )
+        oh_pct_str = f"{r['overhead_pct']:.1f}%" if r.get("overhead_pct") is not None else "N/A"
 
         error_disp = r["error_desc"][:28] if r["error_desc"] else ""
 
@@ -1816,7 +1888,9 @@ def main() -> None:
         else:
             c_str = "N/A"
         m_budget = RE_BUDGET.search(r["run_name"])
-        stage_disp = m_budget.group(1) if m_budget else ("stable" if r["stage"] == "stable" else "decay")
+        stage_disp = (
+            m_budget.group(1) if m_budget else ("stable" if r["stage"] == "stable" else "decay")
+        )
         nodes_str = str(r["nodes"]) if r.get("nodes") is not None else "N/A"
 
         print(
@@ -1876,14 +1950,16 @@ def main() -> None:
                     gpu_h = _gpu_parse_elapsed(d["elapsed"]) * d["gpus"]
                     exp_gpu_h[exp_name] = exp_gpu_h.get(exp_name, 0.0) + gpu_h
                     grand_gpu_total += gpu_h
-                    gpu_csv_rows.append({
-                        "experiment": exp_name,
-                        "job_id":     job_id,
-                        "state":      d["state"],
-                        "elapsed":    d["elapsed"],
-                        "gpus":       d["gpus"],
-                        "gpu_hours":  round(gpu_h, 1),
-                    })
+                    gpu_csv_rows.append(
+                        {
+                            "experiment": exp_name,
+                            "job_id": job_id,
+                            "state": d["state"],
+                            "elapsed": d["elapsed"],
+                            "gpus": d["gpus"],
+                            "gpu_hours": round(gpu_h, 1),
+                        }
+                    )
         except SystemExit:
             pass
 
@@ -1904,10 +1980,10 @@ def main() -> None:
     for r in rows:
         rn = r["run_name"]
         if r.get("gpu_hours") is None and r.get("cluster") == _foreign_cluster:
-            avg_tp   = r.get("avg_tok_per_gpu")
-            tok_b    = r.get("tokens_b")
+            avg_tp = r.get("avg_tok_per_gpu")
+            tok_b = r.get("tokens_b")
             tr_iters = r.get("train_iters")
-            last_it  = r.get("last_iter")
+            last_it = r.get("last_iter")
             if avg_tp and avg_tp > 0 and tr_iters and tr_iters > 0 and tok_b and last_it:
                 tokens_per_iter = tok_b * 1e9 / tr_iters
                 start_iter = _run_prev_last_iter.get(rn, 0)
@@ -1926,9 +2002,7 @@ def main() -> None:
     _foreign_run_names = {r["run_name"] for r in rows if r.get("cluster") == _foreign_cluster}
     for r in rows:
         is_foreign_row = r.get("cluster") == _foreign_cluster
-        is_undetected_foreign = (
-            r["run_name"] in _foreign_run_names and r.get("gpu_hours") is None
-        )
+        is_undetected_foreign = r["run_name"] in _foreign_run_names and r.get("gpu_hours") is None
         if is_foreign_row or is_undetected_foreign:
             # TTFI always unknown without sacct start time
             r["ttfi_min"] = None
@@ -2033,14 +2107,14 @@ def main() -> None:
     run_remaining: dict[str, tuple[float | None, bool]] = {}
     for _rn, _rs, _rt, _ in run_specs:
         _run_rows_r = [r for r in rows if r["run_name"] == _rn]
-        _latest_r   = _run_rows_r[-1] if _run_rows_r else {}
-        _status_r   = _latest_r.get("status_word", "NOT_LAUNCHED")
-        _h_r        = summary_gpu_h.get(_rn)
-        _prog_r     = _latest_r.get("progress")
+        _latest_r = _run_rows_r[-1] if _run_rows_r else {}
+        _status_r = _latest_r.get("status_word", "NOT_LAUNCHED")
+        _h_r = summary_gpu_h.get(_rn)
+        _prog_r = _latest_r.get("progress")
         # Reference throughput: for NOT_LAUNCHED runs prefer gbsz-matched stable avg,
         # otherwise prefer stable sibling, then own data, then global mean.
-        _stable_rn  = decay_to_stable.get(_rn)  # None for stable runs
-        _gbsz_rn    = run_to_gbsz.get(_rn)
+        _stable_rn = decay_to_stable.get(_rn)  # None for stable runs
+        _gbsz_rn = run_to_gbsz.get(_rn)
         if _status_r == "NOT_LAUNCHED":
             _ref_tok = (
                 (_gbsz_stable_avg_tok.get(_gbsz_rn) if _gbsz_rn is not None else None)
@@ -2049,14 +2123,10 @@ def main() -> None:
                 or _ref_avg_tok_per_gpu
             )
         else:
-            _ref_tok = (
-                _run_avg_tok.get(_stable_rn)
-                or _run_avg_tok.get(_rn)
-                or _ref_avg_tok_per_gpu
-            )
+            _ref_tok = _run_avg_tok.get(_stable_rn) or _run_avg_tok.get(_rn) or _ref_avg_tok_per_gpu
         # Effective token count: for decay runs subtract the stable branch-point tokens.
         # For stable runs (or decay runs with no ckpt_tokens info), use full budget.
-        _ckpt_toks  = _stage_ckpt_tokens.get(_rs, 0) if _rs != "stable" else 0
+        _ckpt_toks = _stage_ckpt_tokens.get(_rs, 0) if _rs != "stable" else 0
         _eff_tokens = max(0, _rt - _ckpt_toks)
         if _status_r == "DONE":
             run_remaining[_rn] = (0.0, False)
@@ -2084,15 +2154,19 @@ def main() -> None:
         print()
         print("Training progress summary:")
         if _ref_avg_tok_per_gpu is not None:
-            print(f"  (~ estimates use stable-run throughput per combo; global fallback: {_ref_avg_tok_per_gpu:,.0f} Tok/s/GPU)")
+            print(
+                f"  (~ estimates use stable-run throughput per combo; global fallback: {_ref_avg_tok_per_gpu:,.0f} Tok/s/GPU)"
+            )
         if args.compute_storage:
-            print("  (Ckpt-GB: measured checkpoints/ size; Ckpt-GB-remaining: estimated storage still needed)")
+            print(
+                "  (Ckpt-GB: measured checkpoints/ size; Ckpt-GB-remaining: estimated storage still needed)"
+            )
         _local = args.machine or "LEO"
         _foreign = "MN5" if _local != "MN5" else "LEO"
         _gpu_h_hdr = (
-            f"  {'GPU-h('+_local+')':>10}  {'GPU-h('+_foreign+')':>10}  {'GPU-h':>8}"
-            if _any_cluster_split else
-            f"  {'GPU-h':>8}"
+            f"  {'GPU-h(' + _local + ')':>10}  {'GPU-h(' + _foreign + ')':>10}  {'GPU-h':>8}"
+            if _any_cluster_split
+            else f"  {'GPU-h':>8}"
         )
         print(
             f"  {'T#':>3}  {'#':>3}  {'Run':<{W_EXP}}  {'Tier':<9}  {'Progress':>9}  {'':>2} {'Status':<12}  {'Clusters':>8}"
@@ -2143,7 +2217,9 @@ def main() -> None:
             color = status_colors.get(_ck, "")
             run_rows = [r for r in rows if r["run_name"] == exp_name]
             _run_cls = {r.get("cluster", "") for r in run_rows if r.get("cluster")}
-            _cluster_tag = "MIX" if len(_run_cls) > 1 else (next(iter(_run_cls)) if _run_cls else "")
+            _cluster_tag = (
+                "MIX" if len(_run_cls) > 1 else (next(iter(_run_cls)) if _run_cls else "")
+            )
             # TTFI GPU-h: sum across all jobs for this run
             ttfi_gpu_h_vals = [r["ttfi_gpu_h"] for r in run_rows if r.get("ttfi_gpu_h") is not None]
             ttfi_gpu_h_sum = sum(ttfi_gpu_h_vals) if ttfi_gpu_h_vals else None
@@ -2166,12 +2242,17 @@ def main() -> None:
             # Only include jobs with known GPU-h so the denominator and numerator
             # are from the same cluster (avoids inflated % from MN5 LowTP with
             # only LEO GPU-h in the denominator).
-            oh_gpu_h_vals = [r["overhead_gpu_h"] for r in run_rows
-                             if r.get("overhead_gpu_h") is not None and r.get("gpu_hours") is not None]
+            oh_gpu_h_vals = [
+                r["overhead_gpu_h"]
+                for r in run_rows
+                if r.get("overhead_gpu_h") is not None and r.get("gpu_hours") is not None
+            ]
             oh_gpu_h_sum = sum(oh_gpu_h_vals) if oh_gpu_h_vals else None
             oh_gpu_h_str = f"{oh_gpu_h_sum:.2f}" if oh_gpu_h_sum is not None else "N/A"
             oh_pct_val = (
-                oh_gpu_h_sum / h * 100.0 if oh_gpu_h_sum is not None and h is not None and h > 0 else None
+                oh_gpu_h_sum / h * 100.0
+                if oh_gpu_h_sum is not None and h is not None and h > 0
+                else None
             )
             oh_pct_str = f"{oh_pct_val:.1f}%" if oh_pct_val is not None else "N/A"
             gpu_h_str = f"{h:.1f}" if h is not None else "N/A"
@@ -2191,7 +2272,11 @@ def main() -> None:
                 _tier_gpu_h_mn5 += _h_mn5
                 grand_gpu_h_mn5 += _h_mn5
             rem_val, rem_est = run_remaining.get(exp_name, (None, False))
-            rem_str = (f"~{rem_val:.1f}" if rem_est else f"{rem_val:.1f}") if rem_val is not None else "N/A"
+            rem_str = (
+                (f"~{rem_val:.1f}" if rem_est else f"{rem_val:.1f}")
+                if rem_val is not None
+                else "N/A"
+            )
             if rem_val is not None:
                 grand_remaining_gpu_h += rem_val
                 _tier_rem_gpu_h += rem_val
@@ -2211,8 +2296,8 @@ def main() -> None:
                     _tier_ckpt_rem_gb += ckpt_rem_val
             _gpu_h_cols = (
                 f"  {_h_leo_str:>10}  {_h_mn5_str:>10}  {gpu_h_str:>8}"
-                if _any_cluster_split else
-                f"  {gpu_h_str:>8}"
+                if _any_cluster_split
+                else f"  {gpu_h_str:>8}"
             )
             print(
                 f"  {tier_idx:>3}  {idx:>3}  {exp_name:<{W_EXP}}  {tier_str:<9}  {prog_str:>9}  {emoji} {color}{status:<12}{RESET}  {_cluster_tag:>8}"
@@ -2232,11 +2317,13 @@ def main() -> None:
                 _t_mn5_s = f"{_tier_gpu_h_mn5:.1f}" if _tier_gpu_h_mn5 else "N/A"
                 _t_rem_s = f"{_tier_rem_gpu_h:.1f}" if _tier_rem_gpu_h else "N/A"
                 _t_ckpt_s = _format_ckpt_gb_total(_tier_ckpt_gb, compute=args.compute_storage)
-                _t_ckpt_rem_s = _format_ckpt_gb_total(_tier_ckpt_rem_gb, compute=args.compute_storage)
+                _t_ckpt_rem_s = _format_ckpt_gb_total(
+                    _tier_ckpt_rem_gb, compute=args.compute_storage
+                )
                 _t_gpu_h_cols = (
                     f"  {_t_leo_s:>10}  {_t_mn5_s:>10}  {_t_gpu_h_s:>8}"
-                    if _any_cluster_split else
-                    f"  {_t_gpu_h_s:>8}"
+                    if _any_cluster_split
+                    else f"  {_t_gpu_h_s:>8}"
                 )
                 print(
                     f"  {'':>3}  {'':>3}  {f'[{_tier_name_cur} total]':<{W_EXP}}  {_tier_name_cur:<9}  {'':>9}  {'':>2} {'':<12}  {'':>8}"
@@ -2269,8 +2356,8 @@ def main() -> None:
         _grand_mn5_s = f"{grand_gpu_h_mn5:.1f}" if grand_gpu_h_mn5 else "N/A"
         _grand_gpu_h_cols = (
             f"  {_grand_leo_s:>10}  {_grand_mn5_s:>10}  {summary_grand_total:>8.1f}"
-            if _any_cluster_split else
-            f"  {summary_grand_total:>8.1f}"
+            if _any_cluster_split
+            else f"  {summary_grand_total:>8.1f}"
         )
         print(
             f"  {'':>3}  {'':>3}  {'TOTAL':<{W_EXP}}  {'':<9}  {'':>9}  {'':>2} {'':<12}"
@@ -2281,6 +2368,7 @@ def main() -> None:
 
     # Summary counts
     from collections import Counter
+
     counts = Counter(r["status_word"] for r in rows)
     print()
     print("Status breakdown:")
@@ -2293,24 +2381,58 @@ def main() -> None:
         _csv_run_cluster_tag: dict[str, str] = {}
         for _rn in {r["run_name"] for r in rows}:
             _cls = {r.get("cluster", "") for r in rows if r["run_name"] == _rn and r.get("cluster")}
-            _csv_run_cluster_tag[_rn] = "MIX" if len(_cls) > 1 else (next(iter(_cls)) if _cls else "")
+            _csv_run_cluster_tag[_rn] = (
+                "MIX" if len(_cls) > 1 else (next(iter(_cls)) if _cls else "")
+            )
 
         csv_fields = [
-            "Run", "JobID", "Machine", "RunClusters", "Owner", "StartTime", "Elapsed",
-            "N_ne(B)", "N(B)", "D(B)", "C(10^18)", "Tier", "Stage",
-            "TotIter", "CurIter", "LastCkpt", "Prog%", "TrainLoss", "ValLoss", "LR", "GBS", "MBS", "Nodes", "Workers",
-            "TFLOP/s/GPU", "Tok/s/GPU", "TTFI(min)", "TTFI-GPU-h",
-            "LowTP-time(h)", "LowTP-GPU-h", "Overhead-time(h)", "Overhead-GPU-h", "GPU-h(LEO)", "GPU-h(MN5)", "GPU-h", "Overhead%",
+            "Run",
+            "JobID",
+            "Machine",
+            "RunClusters",
+            "Owner",
+            "StartTime",
+            "Elapsed",
+            "N_ne(B)",
+            "N(B)",
+            "D(B)",
+            "C(10^18)",
+            "Tier",
+            "Stage",
+            "TotIter",
+            "CurIter",
+            "LastCkpt",
+            "Prog%",
+            "TrainLoss",
+            "ValLoss",
+            "LR",
+            "GBS",
+            "MBS",
+            "Nodes",
+            "Workers",
+            "TFLOP/s/GPU",
+            "Tok/s/GPU",
+            "TTFI(min)",
+            "TTFI-GPU-h",
+            "LowTP-time(h)",
+            "LowTP-GPU-h",
+            "Overhead-time(h)",
+            "Overhead-GPU-h",
+            "GPU-h(LEO)",
+            "GPU-h(MN5)",
+            "GPU-h",
+            "Overhead%",
             "Remaining-GPU-h",
-            "Emoji", "Status", "Action", "Error",
+            "Emoji",
+            "Status",
+            "Action",
+            "Error",
         ]
         csv_path = Path(args.csv)
         csv_path.parent.mkdir(parents=True, exist_ok=True)
         # Pre-compute which job_id is the latest for each run (remaining GPU-h
         # is a per-run estimate, so we only populate it on the latest-job row).
-        _csv_latest_job: dict[str, str] = {
-            rn: jids[-1] for rn, jids in run_job_map.items() if jids
-        }
+        _csv_latest_job: dict[str, str] = {rn: jids[-1] for rn, jids in run_job_map.items() if jids}
         with csv_path.open("w", newline="") as f:
             writer = csv.DictWriter(f, fieldnames=csv_fields)
             writer.writeheader()
@@ -2322,68 +2444,107 @@ def main() -> None:
                     if r["transformer_params_b"] is not None and r.get("tokens_b") is not None
                     else ""
                 )
-                _is_latest_csv = (
-                    r["job_id"] == ""
-                    or r["job_id"] == _csv_latest_job.get(r["run_name"])
+                _is_latest_csv = r["job_id"] == "" or r["job_id"] == _csv_latest_job.get(
+                    r["run_name"]
                 )
                 _rem_v_csv, _rem_est_csv = (
-                    run_remaining.get(r["run_name"], (None, False)) if _is_latest_csv else (None, False)
+                    run_remaining.get(r["run_name"], (None, False))
+                    if _is_latest_csv
+                    else (None, False)
                 )
                 rem_gpu_h_csv = (
                     (f"~{_rem_v_csv:.1f}" if _rem_est_csv else f"{_rem_v_csv:.1f}")
-                    if _rem_v_csv is not None else ""
+                    if _rem_v_csv is not None
+                    else ""
                 )
-                writer.writerow({
-                    "Run":         r["run_name"],
-                    "JobID":       r["job_id"],
-                    "Machine":     r.get("cluster", ""),
-                    "RunClusters": _csv_run_cluster_tag.get(r["run_name"], ""),
-                    "Owner":       r.get("owner", ""),
-                    "StartTime":   r.get("sacct_start_str", ""),
-                    "Elapsed":     r.get("sacct_elapsed", ""),
-                    "N_ne(B)":     f"{r['transformer_params_b']:.2f}" if r["transformer_params_b"] is not None else "",
-                    "N(B)":        f"{r['total_params_b']:.2f}" if r["total_params_b"] is not None else "",
-                    "D(B)":        int(r["tokens_b"]) if r.get("tokens_b") is not None else "",
-                    "C(10^18)":    c_val,
-                    "Tier":        r.get("tier", ""),
-                    "Stage":       sd,
-                    "TotIter":     r["train_iters"] if r["train_iters"] is not None else "",
-                    "CurIter":     r.get("last_iter") if r.get("last_iter") is not None else "",
-                    "LastCkpt":    r["last_ckpt"] if r["last_ckpt"] is not None else "",
-                    "Prog%":       f"{r['progress']:.1f}" if r.get("progress") is not None else "",
-                    "TrainLoss":   f"{r['last_train_loss']:.4f}" if r.get("last_train_loss") is not None else "",
-                    "ValLoss":     f"{r['last_val_loss']:.4f}" if r.get("last_val_loss") is not None else "",
-                    "LR":          f"{r['lr']:.4f}" if r["lr"] is not None else "",
-                    "GBS":         r["global_batch_size"] if r["global_batch_size"] is not None else "",
-                    "MBS":         r["micro_batch_size"] if r["micro_batch_size"] is not None else "",
-                    "Nodes":       r["nodes"] if r.get("nodes") is not None else "",
-                    "Workers":     r["num_workers"] if r["num_workers"] is not None else "",
-                    "TFLOP/s/GPU":   f"{r['avg_tflop_per_gpu']:.1f}" if r["avg_tflop_per_gpu"] is not None else "",
-                    "Tok/s/GPU":     f"{r['avg_tok_per_gpu']:.0f}" if r["avg_tok_per_gpu"] is not None else "",
-                    "TTFI(min)":     f"{r['ttfi_min']:.1f}" if r.get("ttfi_min") is not None else "",
-                    "TTFI-GPU-h":    f"{r['ttfi_gpu_h']:.2f}" if r.get("ttfi_gpu_h") is not None else "",
-                    "LowTP-time(h)":    f"{r['time_lost_h']:.4f}"    if r.get("time_lost_h")    is not None else "",
-                    "LowTP-GPU-h":      f"{r['gpu_h_lost']:.4f}"     if r.get("gpu_h_lost")     is not None else "",
-                    "Overhead-time(h)": f"{r['overhead_time_h']:.4f}" if r.get("overhead_time_h") is not None else "",
-                    "Overhead-GPU-h":   f"{r['overhead_gpu_h']:.4f}"  if r.get("overhead_gpu_h")  is not None else "",
-                    "GPU-h(LEO)":       f"{r['gpu_hours']:.1f}" if r.get("gpu_hours") is not None and r.get("cluster") == args.machine else "",
-                    "GPU-h(MN5)":       f"{r['gpu_hours']:.1f}" if r.get("gpu_hours") is not None and r.get("cluster") == _foreign_cluster else "",
-                    "GPU-h":            f"{r['gpu_hours']:.1f}"       if r["gpu_hours"]           is not None else "",
-                    "Overhead%":        f"{r['overhead_pct']:.2f}"    if r.get("overhead_pct")    is not None else "",
-                    "Remaining-GPU-h":  rem_gpu_h_csv,
-                    "Emoji":         r["status_emoji"],
-                    "Status":      r["status_word"],
-                    "Action":      r["action_word"],
-                    "Error":       r["error_desc"],
-                })
+                writer.writerow(
+                    {
+                        "Run": r["run_name"],
+                        "JobID": r["job_id"],
+                        "Machine": r.get("cluster", ""),
+                        "RunClusters": _csv_run_cluster_tag.get(r["run_name"], ""),
+                        "Owner": r.get("owner", ""),
+                        "StartTime": r.get("sacct_start_str", ""),
+                        "Elapsed": r.get("sacct_elapsed", ""),
+                        "N_ne(B)": f"{r['transformer_params_b']:.2f}"
+                        if r["transformer_params_b"] is not None
+                        else "",
+                        "N(B)": f"{r['total_params_b']:.2f}"
+                        if r["total_params_b"] is not None
+                        else "",
+                        "D(B)": int(r["tokens_b"]) if r.get("tokens_b") is not None else "",
+                        "C(10^18)": c_val,
+                        "Tier": r.get("tier", ""),
+                        "Stage": sd,
+                        "TotIter": r["train_iters"] if r["train_iters"] is not None else "",
+                        "CurIter": r.get("last_iter") if r.get("last_iter") is not None else "",
+                        "LastCkpt": r["last_ckpt"] if r["last_ckpt"] is not None else "",
+                        "Prog%": f"{r['progress']:.1f}" if r.get("progress") is not None else "",
+                        "TrainLoss": f"{r['last_train_loss']:.4f}"
+                        if r.get("last_train_loss") is not None
+                        else "",
+                        "ValLoss": f"{r['last_val_loss']:.4f}"
+                        if r.get("last_val_loss") is not None
+                        else "",
+                        "LR": f"{r['lr']:.4f}" if r["lr"] is not None else "",
+                        "GBS": r["global_batch_size"] if r["global_batch_size"] is not None else "",
+                        "MBS": r["micro_batch_size"] if r["micro_batch_size"] is not None else "",
+                        "Nodes": r["nodes"] if r.get("nodes") is not None else "",
+                        "Workers": r["num_workers"] if r["num_workers"] is not None else "",
+                        "TFLOP/s/GPU": f"{r['avg_tflop_per_gpu']:.1f}"
+                        if r["avg_tflop_per_gpu"] is not None
+                        else "",
+                        "Tok/s/GPU": f"{r['avg_tok_per_gpu']:.0f}"
+                        if r["avg_tok_per_gpu"] is not None
+                        else "",
+                        "TTFI(min)": f"{r['ttfi_min']:.1f}"
+                        if r.get("ttfi_min") is not None
+                        else "",
+                        "TTFI-GPU-h": f"{r['ttfi_gpu_h']:.2f}"
+                        if r.get("ttfi_gpu_h") is not None
+                        else "",
+                        "LowTP-time(h)": f"{r['time_lost_h']:.4f}"
+                        if r.get("time_lost_h") is not None
+                        else "",
+                        "LowTP-GPU-h": f"{r['gpu_h_lost']:.4f}"
+                        if r.get("gpu_h_lost") is not None
+                        else "",
+                        "Overhead-time(h)": f"{r['overhead_time_h']:.4f}"
+                        if r.get("overhead_time_h") is not None
+                        else "",
+                        "Overhead-GPU-h": f"{r['overhead_gpu_h']:.4f}"
+                        if r.get("overhead_gpu_h") is not None
+                        else "",
+                        "GPU-h(LEO)": f"{r['gpu_hours']:.1f}"
+                        if r.get("gpu_hours") is not None and r.get("cluster") == args.machine
+                        else "",
+                        "GPU-h(MN5)": f"{r['gpu_hours']:.1f}"
+                        if r.get("gpu_hours") is not None and r.get("cluster") == _foreign_cluster
+                        else "",
+                        "GPU-h": f"{r['gpu_hours']:.1f}" if r["gpu_hours"] is not None else "",
+                        "Overhead%": f"{r['overhead_pct']:.2f}"
+                        if r.get("overhead_pct") is not None
+                        else "",
+                        "Remaining-GPU-h": rem_gpu_h_csv,
+                        "Emoji": r["status_emoji"],
+                        "Status": r["status_word"],
+                        "Action": r["action_word"],
+                        "Error": r["error_desc"],
+                    }
+                )
         print(f"\nWrote {len(rows)} rows to {csv_path}")
 
     if gpu_csv_rows:
-        gpu_csv_rows.append({
-            "experiment": "TOTAL",
-            "job_id": "", "state": "", "elapsed": "", "gpus": "",
-            "gpu_hours": round(grand_gpu_total, 1),
-        })
+        gpu_csv_rows.append(
+            {
+                "experiment": "TOTAL",
+                "job_id": "",
+                "state": "",
+                "elapsed": "",
+                "gpus": "",
+                "gpu_hours": round(grand_gpu_total, 1),
+            }
+        )
         gpu_csv_path = resolved_base / "gpu_hours.csv"
         gpu_csv_path.parent.mkdir(parents=True, exist_ok=True)
         with gpu_csv_path.open("w", newline="") as f:
@@ -2421,28 +2582,28 @@ def main() -> None:
         with md_path.open("w") as f:
             f.write(f"_Updated training progress: {now_str}_  \n")
             f.write(f"_Updated compute spending: {spending_str}_\n\n")
-            f.write(f"# Sweep run status\n\n")
+            f.write("# Sweep run status\n\n")
             f.write(f"**Config:** `{args.config}`  \n")
             f.write(f"**Results:** `{resolved_base}`\n\n")
 
             # Experiment summary GPU consumption + progress table
             f.write("## Training progress summary\n\n")
             if _ref_avg_tok_per_gpu is not None:
-                f.write(f"_~ estimates use stable-run throughput per combo; global fallback: {_ref_avg_tok_per_gpu:,.0f} Tok/s/GPU_\n\n")
+                f.write(
+                    f"_~ estimates use stable-run throughput per combo; global fallback: {_ref_avg_tok_per_gpu:,.0f} Tok/s/GPU_\n\n"
+                )
             if args.compute_storage:
-                f.write("_Ckpt-GB: measured `checkpoints/` size; Ckpt-GB-remaining: estimated storage still needed_\n\n")
-            _md_gpu_h_hdr = (
-                "GPU-h(LEO) | GPU-h(MN5) | GPU-h"
-                if _any_cluster_split else "GPU-h"
-            )
-            _md_gpu_h_sep = (
-                " --- | --- | ---"
-                if _any_cluster_split else " ---"
-            )
+                f.write(
+                    "_Ckpt-GB: measured `checkpoints/` size; Ckpt-GB-remaining: estimated storage still needed_\n\n"
+                )
+            _md_gpu_h_hdr = "GPU-h(LEO) | GPU-h(MN5) | GPU-h" if _any_cluster_split else "GPU-h"
+            _md_gpu_h_sep = " --- | --- | ---" if _any_cluster_split else " ---"
             f.write(
                 f"| T# | # | Experiment | Tier | Progress | Status | Clusters | TTFI-GPU-h | LowTP-GPU-h | Overhead-GPU-h | {_md_gpu_h_hdr} | Overhead% | Remaining-GPU-h | Ckpt-GB | Ckpt-GB-remaining |\n"
             )
-            f.write(f"| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |{_md_gpu_h_sep} | --- | --- | --- | --- |\n")
+            f.write(
+                f"| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |{_md_gpu_h_sep} | --- | --- | --- | --- |\n"
+            )
             grand_lt_time_md = 0.0
             grand_lt_gpu_h_md = 0.0
             grand_ttfi_gpu_h_md = 0.0
@@ -2482,8 +2643,14 @@ def main() -> None:
                 emoji = latest.get("status_emoji", "")
                 status = latest.get("status_word", "")
                 _md_run_cls = {r.get("cluster", "") for r in run_rows if r.get("cluster")}
-                _md_cluster_tag = "MIX" if len(_md_run_cls) > 1 else (next(iter(_md_run_cls)) if _md_run_cls else "")
-                ttfi_gpu_h_vals_md = [r["ttfi_gpu_h"] for r in run_rows if r.get("ttfi_gpu_h") is not None]
+                _md_cluster_tag = (
+                    "MIX"
+                    if len(_md_run_cls) > 1
+                    else (next(iter(_md_run_cls)) if _md_run_cls else "")
+                )
+                ttfi_gpu_h_vals_md = [
+                    r["ttfi_gpu_h"] for r in run_rows if r.get("ttfi_gpu_h") is not None
+                ]
                 ttfi_gpu_h_md_sum = sum(ttfi_gpu_h_vals_md) if ttfi_gpu_h_vals_md else None
                 ttfi_gpu_h_md_str = (
                     f"{ttfi_gpu_h_md_sum:.2f}" if ttfi_gpu_h_md_sum is not None else "N/A"
@@ -2491,8 +2658,12 @@ def main() -> None:
                 if ttfi_gpu_h_md_sum is not None:
                     grand_ttfi_gpu_h_md += ttfi_gpu_h_md_sum
                     _tier_ttfi_gpu_h_md += ttfi_gpu_h_md_sum
-                lt_time_vals_md = [r["time_lost_h"] for r in run_rows if r.get("time_lost_h") is not None]
-                lt_gpu_h_vals_md = [r["gpu_h_lost"] for r in run_rows if r.get("gpu_h_lost") is not None]
+                lt_time_vals_md = [
+                    r["time_lost_h"] for r in run_rows if r.get("time_lost_h") is not None
+                ]
+                lt_gpu_h_vals_md = [
+                    r["gpu_h_lost"] for r in run_rows if r.get("gpu_h_lost") is not None
+                ]
                 lt_time = sum(lt_time_vals_md) if lt_time_vals_md else None
                 lt_gpu_h = sum(lt_gpu_h_vals_md) if lt_gpu_h_vals_md else None
                 lt_gpu_h_md = f"{lt_gpu_h:.2f}" if lt_gpu_h is not None else "N/A"
@@ -2501,8 +2672,11 @@ def main() -> None:
                 if lt_gpu_h is not None:
                     grand_lt_gpu_h_md += lt_gpu_h
                     _tier_lt_gpu_h_md += lt_gpu_h
-                oh_gpu_h_vals_md = [r["overhead_gpu_h"] for r in run_rows
-                                    if r.get("overhead_gpu_h") is not None and r.get("gpu_hours") is not None]
+                oh_gpu_h_vals_md = [
+                    r["overhead_gpu_h"]
+                    for r in run_rows
+                    if r.get("overhead_gpu_h") is not None and r.get("gpu_hours") is not None
+                ]
                 oh_gpu_h_md_sum = sum(oh_gpu_h_vals_md) if oh_gpu_h_vals_md else None
                 oh_gpu_h_md_str = f"{oh_gpu_h_md_sum:.2f}" if oh_gpu_h_md_sum is not None else "N/A"
                 oh_pct_md = (
@@ -2530,7 +2704,8 @@ def main() -> None:
                 rem_val_md, rem_est_md = run_remaining.get(exp_name, (None, False))
                 rem_md_str = (
                     (f"~{rem_val_md:.1f}" if rem_est_md else f"{rem_val_md:.1f}")
-                    if rem_val_md is not None else "N/A"
+                    if rem_val_md is not None
+                    else "N/A"
                 )
                 if rem_val_md is not None:
                     _tier_rem_gpu_h_md += rem_val_md
@@ -2541,7 +2716,9 @@ def main() -> None:
                     run_checkpoint_storage, exp_name, compute=args.compute_storage, md=True
                 )
                 if args.compute_storage:
-                    ckpt_val_md, ckpt_rem_val_md = run_checkpoint_storage.get(exp_name, (None, None))
+                    ckpt_val_md, ckpt_rem_val_md = run_checkpoint_storage.get(
+                        exp_name, (None, None)
+                    )
                     if ckpt_val_md is not None:
                         grand_ckpt_gb_md += ckpt_val_md
                         _tier_ckpt_gb_md += ckpt_val_md
@@ -2550,7 +2727,8 @@ def main() -> None:
                         _tier_ckpt_rem_gb_md += ckpt_rem_val_md
                 _md_run_gpu_h_cols = (
                     f" {_h_leo_md_str} | {_h_mn5_md_str} | {gpu_h_md_str}"
-                    if _any_cluster_split else f" {gpu_h_md_str}"
+                    if _any_cluster_split
+                    else f" {gpu_h_md_str}"
                 )
                 f.write(
                     f"| {tier_idx_md} | {idx} | {exp_name} | {tier_str} | {prog_str} | {emoji} {status}"
@@ -2559,9 +2737,13 @@ def main() -> None:
                     f" | {ckpt_md_str or '—'} | {ckpt_rem_md_str or '—'} |\n"
                 )
                 is_last_md = idx >= len(sorted_exps_md)
-                next_tier_md_str = "" if is_last_md else run_tier_map.get(sorted_exps_md[idx][0], "")
+                next_tier_md_str = (
+                    "" if is_last_md else run_tier_map.get(sorted_exps_md[idx][0], "")
+                )
                 if is_last_md or next_tier_md_str != tier_str:
-                    _t_oh_pct_md = _tier_oh_gpu_h_md / _tier_gpu_h_md * 100.0 if _tier_gpu_h_md > 0 else None
+                    _t_oh_pct_md = (
+                        _tier_oh_gpu_h_md / _tier_gpu_h_md * 100.0 if _tier_gpu_h_md > 0 else None
+                    )
                     _t_oh_pct_md_s = f"{_t_oh_pct_md:.1f}%" if _t_oh_pct_md is not None else "N/A"
                     _t_ttfi_md_s = f"{_tier_ttfi_gpu_h_md:.2f}" if _tier_ttfi_gpu_h_md else "N/A"
                     _t_oh_md_s = f"{_tier_oh_gpu_h_md:.2f}" if _tier_oh_gpu_h_md else "N/A"
@@ -2577,7 +2759,8 @@ def main() -> None:
                     )
                     _md_tier_gpu_h_cols = (
                         f" **{_t_leo_md_s}** | **{_t_mn5_md_s}** | **{_t_gpu_h_md_s}**"
-                        if _any_cluster_split else f" **{_t_gpu_h_md_s}**"
+                        if _any_cluster_split
+                        else f" **{_t_gpu_h_md_s}**"
                     )
                     f.write(
                         f"| | | **[{_tier_name_md} total]** | **{_tier_name_md}** | | | |"
@@ -2614,7 +2797,8 @@ def main() -> None:
             _grand_mn5_md_s = f"{grand_gpu_h_mn5_md:.1f}" if grand_gpu_h_mn5_md else "N/A"
             _md_grand_gpu_h_cols = (
                 f" **{_grand_leo_md_s}** | **{_grand_mn5_md_s}** | **{summary_grand_total:.1f}**"
-                if _any_cluster_split else f" **{summary_grand_total:.1f}**"
+                if _any_cluster_split
+                else f" **{summary_grand_total:.1f}**"
             )
             f.write(
                 f"| | | **TOTAL** | | | | | **{grand_ttfi_gpu_h_md:.2f}** | **{grand_lt_gpu_h_md:.2f}**"
@@ -2626,6 +2810,7 @@ def main() -> None:
             # Status summary
             f.write("## Status breakdown\n\n")
             from collections import Counter
+
             counts = Counter(r["status_word"] for r in rows)
             for status, cnt in sorted(counts.items()):
                 f.write(f"- **{status}**: {cnt}\n")

--- a/tools/progress_tracker.py
+++ b/tools/progress_tracker.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-"""Sweep run status table for multilingual_scaling experiments.
+"""
+Sweep run status table for multilingual_scaling experiments.
 
 Reads a sweep YAML config, discovers all expected runs under the results directory,
 and prints a detailed per-Slurm-job table with training metrics, throughput, GPU
@@ -27,8 +28,10 @@ import re
 import subprocess
 import sys
 from collections import OrderedDict
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from pathlib import Path
+from statistics import mean, median
 from typing import Any
 
 import yaml
@@ -40,14 +43,14 @@ for _d in (_tools_dir, _scripts_dir):
     if _d not in sys.path:
         sys.path.insert(0, _d)
 
-from gpu_hours import (  # noqa: E402
+from gpu_hours import (
     collect_job_ids as _gpu_collect_job_ids,
     query_sacct as _gpu_query_sacct,
     parse_elapsed as _gpu_parse_elapsed,
 )
-from low_throughput_analysis import analyze_job as _analyze_low_throughput_job  # noqa: E402
-from megatron_throughput_from_logs import load_or_compute_throughput as _compute_throughput  # noqa: E402
-from validate_sweep_runs import (  # noqa: E402
+from low_throughput_analysis import analyze_job as _analyze_low_throughput_job
+from megatron_throughput_from_logs import load_or_compute_throughput as _compute_throughput
+from validate_sweep_runs import (
     _resolve_defaults,
     render_job_name,
     substitute_omegaconf_path_vars as _subst,
@@ -60,16 +63,22 @@ from validate_sweep_runs import (  # noqa: E402
 RE_ARG = re.compile(r"\[default\d+\]:\s{2}(\w+)\s+\.+\s+(.+)")
 
 # Model parameter count lines
-RE_TOTAL_PARAMS_B = re.compile(r"\[default0\]:Total number of parameters in billions:\s+([\d.]+)")
+RE_TOTAL_PARAMS_B = re.compile(
+    r"\[default0\]:Total number of parameters in billions:\s+([\d.]+)"
+)
 RE_TRANSFORMER_PARAMS_B = re.compile(
     r"\[default0\]:Number of parameters in transformer block in billions:\s+([\d.]+)"
 )
 
 # Training loss from iteration lines: "lm loss: 3.1416"
-RE_TRAIN_LOSS = re.compile(r"iteration\s+\d+/\s*\d+\s*\|[^\n]*lm loss:\s*([\d.eE+\-]+)")
+RE_TRAIN_LOSS = re.compile(
+    r"iteration\s+\d+/\s*\d+\s*\|[^\n]*lm loss:\s*([\d.eE+\-]+)"
+)
 
 # Validation loss lines: "validation loss at iteration X | lm loss value: Y"
-RE_VAL_LOSS = re.compile(r"validation loss at[^\n]*\|[^\n]*lm loss value:\s*([\d.eE+\-]+)")
+RE_VAL_LOSS = re.compile(
+    r"validation loss at[^\n]*\|[^\n]*lm loss value:\s*([\d.eE+\-]+)"
+)
 
 # Throughput / iteration line
 RE_ITER = re.compile(
@@ -93,8 +102,13 @@ RE_SEGFAULT = re.compile(r"Segmentation fault|signal 11\b", re.IGNORECASE)
 RE_OOM = re.compile(r"OutOfMemoryError|CUDA out of memory", re.IGNORECASE)
 RE_FATAL = re.compile(r"\bFATAL ERROR\b", re.IGNORECASE)
 RE_TIME_LIMIT = re.compile(r"DUE TO TIME LIMIT", re.IGNORECASE)
-RE_SIGTERM = re.compile(r"SignalException.*?sigval=Signals\.SIGTERM|signal: 15\b", re.IGNORECASE)
-RE_WANDB_SUMMARY = re.compile(r"wandb:\s+Run summary:|wandb:\s+Synced\s+\S", re.IGNORECASE)
+RE_NODE_FAILURE = re.compile(r"DUE TO NODE FAILURE|Node failure on\b|NODE_FAIL", re.IGNORECASE)
+RE_SIGTERM = re.compile(
+    r"SignalException.*?sigval=Signals\.SIGTERM|signal: 15\b", re.IGNORECASE
+)
+RE_WANDB_SUMMARY = re.compile(
+    r"wandb:\s+Run summary:|wandb:\s+Synced\s+\S", re.IGNORECASE
+)
 
 # SBATCH directives
 RE_SBATCH_NODES = re.compile(r"^#SBATCH\s+--nodes[= ](\d+)", re.MULTILINE)
@@ -107,19 +121,77 @@ RE_BUDGET = re.compile(r"_(stable|decay)(\d+BT)$")
 
 TS_FMT = "%Y-%m-%d %H:%M:%S"
 
+TIER_SORT_ORDER = {"center": 0, "cross": 1, "diagonal": 2}
+SUMMARY_MD_TIER_SEP = "| — | — | — | — | — | — | — | — | — | — | — | — | — | — |"
+
+# Checkpoint save cadence: save_interval = SAVE_INTERVAL_NUM // global_batch_size
+_SAVE_INTERVAL_NUM = 512_000
+_DECAY_BUDGETS_TOK = (
+    6_000_000_000,
+    12_000_000_000,
+    20_000_000_000,
+    30_000_000_000,
+    50_000_000_000,
+    80_000_000_000,
+    120_000_000_000,
+    200_000_000_000,
+    300_000_000_000,
+)
+
+
+def _summary_table_sort_key(
+    exp_name: str,
+    run_tier_map: dict[str, str],
+    run_stage_map: dict[str, str],
+) -> tuple[int, int, str]:
+    tier = run_tier_map.get(exp_name, "")
+    stage = run_stage_map.get(exp_name, "")
+    return (
+        TIER_SORT_ORDER.get(tier, 99),
+        0 if stage == "stable" else 1,
+        exp_name,
+    )
+
+
+def _build_summary_exp_gpu_h(
+    run_specs: list[tuple[str, str, int, str]],
+    exp_gpu_h: dict[str, float],
+    rows: list[dict[str, Any]],
+) -> dict[str, float | None]:
+    """GPU-h per experiment for the summary table.
+
+    Includes every run from *run_specs*.  Prefer *exp_gpu_h* (sacct via
+    gpu_hours.collect_job_ids); fill gaps from per-row GPU-h in *rows*.
+    """
+    row_gpu_h: dict[str, float] = {}
+    for r in rows:
+        if r["gpu_hours"] is not None:
+            rn = r["run_name"]
+            row_gpu_h[rn] = row_gpu_h.get(rn, 0.0) + r["gpu_hours"]
+
+    summary: dict[str, float | None] = {}
+    for run_name, _stage, _tok, _tier in run_specs:
+        if run_name in exp_gpu_h:
+            summary[run_name] = exp_gpu_h[run_name]
+        elif run_name in row_gpu_h:
+            summary[run_name] = row_gpu_h[run_name]
+        else:
+            summary[run_name] = None
+    return summary
+
+
 # ── Monitor-state event classification ───────────────────────────────────────
 
 _CLEAN_RESTART_EVENTS = frozenset({"time_limit", "inactive"})
-_HARD_ERROR_EVENTS = frozenset(
-    {"segmentation_fault", "error", "bus_error", "nan_loss", "connection_failure"}
-)
-_FINISH_EVENTS = frozenset({"finished_training", "finish"})
+_HARD_ERROR_EVENTS    = frozenset({"segmentation_fault", "error", "bus_error",
+                                    "nan_loss", "connection_failure"})
+_FINISH_EVENTS        = frozenset({"finished_training", "finish"})
 
 _EVENT_ERROR_DESC: dict[str, str] = {
     "segmentation_fault": "Segmentation fault",
-    "error": "Exit code 1",
-    "bus_error": "Bus error",
-    "nan_loss": "NaN loss",
+    "error":              "Exit code 1",
+    "bus_error":          "Bus error",
+    "nan_loss":           "NaN loss",
     "connection_failure": "Connection failure",
 }
 
@@ -128,21 +200,20 @@ _EVENT_ERROR_DESC: dict[str, str] = {
 _EVENT_MATCH_TOLERANCE_S = 300.0
 
 
+
 def _eval_token_set(s: str) -> set[int]:
-    """Evaluate a Python set-literal string like '{6_000_000_000}' or 'set()'
-    into a set of ints."""
+    """Evaluate a Python set-literal string like '{6_000_000_000}' or 'set()' into a set of ints."""
     if not s:
         return set()
     try:
         result = eval(s)  # safe: these are only integer set literals from the YAML
-        return {int(x) for x in result} if isinstance(result, (set, frozenset)) else set()
+        return set(int(x) for x in result) if isinstance(result, (set, frozenset)) else set()
     except Exception:
         return set()
 
 
 def parse_config(config_path: str) -> dict:
-    """Parse sweep config and return all valid (run_name, stage, tokens)
-    combos.
+    """Parse sweep config and return all valid (run_name, stage, tokens) combos.
 
     The sweep uses a per-combo filter: each Group-1 entry carries
     center/cross/diagonal_tokens_set; a decay stage is only valid for a combo
@@ -167,12 +238,17 @@ def parse_config(config_path: str) -> dict:
     job_name_tpl: str | None = None
 
     # Pass 1 – collect per-combo data (Group 1 entries) and all decay stage defs (Group 2).
-    combos: list[dict] = []  # {lr, gbsz, stable_tokens, valid_decay_tokens: set[int]}
+    combos: list[dict] = []          # {lr, gbsz, stable_tokens, valid_decay_tokens: set[int]}
     all_decay_stages: OrderedDict[str, int] = OrderedDict()  # stage_name -> token_budget
+
+    # Used by the "new format" where stable entries carry an explicit stage name (e.g.
+    # "stable12BT") and are immediately followed by their associated decay list.
+    _pending_stable_combo: dict | None = None
 
     for group in groups:
         if group.get("type") != "list" or "configs" not in group:
             continue
+        _pending_stable_combo = None  # reset per group
         for entry in group["configs"]:
             if not isinstance(entry, dict):
                 continue
@@ -182,7 +258,7 @@ def parse_config(config_path: str) -> dict:
                 job_name_tpl = entry["job.name"]
                 continue
 
-            # Group 1: (lr, gbsz) hyperparameter combo entries
+            # Group 1 (old format): pure (lr, gbsz) combo entries without 'stage'
             if (
                 "backend.megatron.lr" in entry
                 and "backend.megatron.global_batch_size" in entry
@@ -194,46 +270,66 @@ def parse_config(config_path: str) -> dict:
                 gbsz = int(entry["backend.megatron.global_batch_size"])
                 stable_tok = int(entry.get("backend.megatron.aux.tokens", aux["tokens"]))
 
-                center = _eval_token_set(
-                    entry.get("backend.megatron.aux.center_tokens_set", "set()")
-                )
+                center = _eval_token_set(entry.get("backend.megatron.aux.center_tokens_set", "set()"))
                 cross = _eval_token_set(entry.get("backend.megatron.aux.cross_tokens_set", "set()"))
-                diagonal = _eval_token_set(
-                    entry.get("backend.megatron.aux.diagonal_tokens_set", "set()")
-                )
+                diagonal = _eval_token_set(entry.get("backend.megatron.aux.diagonal_tokens_set", "set()"))
                 valid_decay_tokens = center | cross | diagonal
 
-                combos.append(
-                    {
-                        "lr": lr,
-                        "gbsz": gbsz,
-                        "stable_tokens": stable_tok,
-                        "valid_decay_tokens": valid_decay_tokens,
-                        "center_tokens": center,
-                        "cross_tokens": cross,
-                        "diagonal_tokens": diagonal,
-                        "stable_launch_tier": str(
-                            entry.get("backend.megatron.aux.stable_launch_tier", "")
-                        ),
-                    }
-                )
+                combos.append({
+                    "lr": lr,
+                    "gbsz": gbsz,
+                    "stable_tokens": stable_tok,
+                    "valid_decay_tokens": valid_decay_tokens,
+                    "center_tokens": center,
+                    "cross_tokens": cross,
+                    "diagonal_tokens": diagonal,
+                    "stable_launch_tier": str(entry.get("backend.megatron.aux.stable_launch_tier", "")),
+                    "stable_stage_name": None,  # old format: use "stable" + job_horizon_suffix
+                })
                 continue
 
-            # Group 2 stable entry: skip (it just sets train_iters formulas)
+            # New format: stable phase entry with an explicit stage name (e.g. "stable12BT").
+            # The adjacent decay list (next type:list entry) provides valid_decay_tokens.
+            _stage_val = entry.get("stage", "")
+            if (
+                isinstance(_stage_val, str) and _stage_val.startswith("stable")
+                and "backend.megatron.lr" in entry
+                and "backend.megatron.global_batch_size" in entry
+                and "backend.megatron.aux.tokens" in entry
+                and entry.get("type") not in ("product", "list")
+            ):
+                _pending_stable_combo = {
+                    "lr": float(entry["backend.megatron.lr"]),
+                    "gbsz": int(entry["backend.megatron.global_batch_size"]),
+                    "stable_tokens": int(entry["backend.megatron.aux.tokens"]),
+                    "valid_decay_tokens": set(),
+                    "center_tokens": set(),
+                    "cross_tokens": set(),
+                    "diagonal_tokens": set(),
+                    "stable_launch_tier": str(entry.get("backend.megatron.aux.stable_launch_tier", "")),
+                    "stable_stage_name": _stage_val,  # new format: pass full name (e.g. "stable12BT")
+                }
+                continue
+
+            # Group 2 stable entry (old format, stage == "stable"): skip
             if entry.get("stage") == "stable":
                 continue
 
-            # Group 2 nested decay list: collect all possible decay stage names
+            # Decay list: collect stage names; if preceded by a new-format stable entry,
+            # associate these decay tokens with that combo.
             if entry.get("type") == "list" and "configs" in entry:
+                _decay_toks: set[int] = set()
                 for dc in entry["configs"]:
-                    if (
-                        isinstance(dc, dict)
-                        and "stage" in dc
-                        and "backend.megatron.aux.tokens" in dc
-                    ):
+                    if isinstance(dc, dict) and "stage" in dc and "backend.megatron.aux.tokens" in dc:
                         stage_name = str(dc["stage"])
                         tok = int(dc["backend.megatron.aux.tokens"])
                         all_decay_stages[stage_name] = tok
+                        _decay_toks.add(tok)
+                if _pending_stable_combo is not None:
+                    _pending_stable_combo["valid_decay_tokens"] = _decay_toks
+                    _pending_stable_combo["center_tokens"] = _decay_toks
+                    combos.append(_pending_stable_combo)
+                    _pending_stable_combo = None
 
     # Build token → stage_name reverse map
     tok_to_stage: dict[int, str] = {tok: name for name, tok in all_decay_stages.items()}
@@ -242,17 +338,249 @@ def parse_config(config_path: str) -> dict:
     params["combos"] = combos
     params["all_decay_stages"] = all_decay_stages
     params["tok_to_stage"] = tok_to_stage
+    params["adam_beta2"] = float(meg.get("adam_beta2", 0.95))
+    params["cooldown_decay_fraction"] = float(aux.get("cooldown_decay_fraction", 0.2))
     return params
+
+
+# ── Checkpoint storage ─────────────────────────────────────────────────────────
+
+def _save_interval(gbsz: int) -> int:
+    return _SAVE_INTERVAL_NUM // gbsz
+
+
+def _train_iters(tokens: int, gbsz: int, seq_length: int) -> int:
+    return (tokens + seq_length * gbsz - 1) // (seq_length * gbsz)
+
+
+def _count_checkpoint_iters(checkpoints_dir: Path) -> int:
+    if not checkpoints_dir.is_dir():
+        return 0
+    return sum(
+        1 for p in checkpoints_dir.iterdir()
+        if p.is_dir() and p.name.startswith("iter_")
+    )
+
+
+def measure_checkpoint_storage_gb(checkpoints_dir: Path, *, timeout_s: int = 180) -> float | None:
+    """Return total checkpoint-directory size in GiB, or None if unavailable."""
+    if not checkpoints_dir.is_dir():
+        return None
+    try:
+        proc = subprocess.run(
+            ["du", "-sb", str(checkpoints_dir)],
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+            check=False,
+        )
+        if proc.returncode == 0 and proc.stdout.strip():
+            nbytes = int(proc.stdout.split()[0])
+            return nbytes / (1024 ** 3)
+    except (OSError, ValueError, subprocess.TimeoutExpired):
+        pass
+    return None
+
+
+def _expected_stable_checkpoint_iters(
+    stable_tokens: int,
+    gbsz: int,
+    seq_length: int,
+    cooldown_decay_fraction: float,
+) -> set[int]:
+    """Unique iteration indices saved by a stable run at completion."""
+    train_iters = _train_iters(stable_tokens, gbsz, seq_length)
+    save_int = _save_interval(gbsz)
+    iters: set[int] = set()
+    step = save_int
+    while step <= train_iters:
+        iters.add(step)
+        step += save_int
+    for budget in _DECAY_BUDGETS_TOK:
+        if budget > stable_tokens:
+            break
+        budget_iters = _train_iters(budget, gbsz, seq_length)
+        iters.add(int(budget_iters * (1.0 - cooldown_decay_fraction)))
+        iters.add(budget_iters)
+    return iters
+
+
+def _expected_decay_checkpoint_iters(
+    decay_tokens: int,
+    gbsz: int,
+    seq_length: int,
+    cooldown_decay_fraction: float,
+) -> set[int]:
+    """Unique iteration indices saved by a decay run at completion."""
+    full_iters = _train_iters(decay_tokens, gbsz, seq_length)
+    start_iter = int(full_iters * (1.0 - cooldown_decay_fraction))
+    save_int = _save_interval(gbsz)
+    iters: set[int] = set()
+    step = ((start_iter // save_int) + 1) * save_int
+    while step <= full_iters:
+        iters.add(step)
+        step += save_int
+    # Short decay phases (< save_interval) still persist a final checkpoint.
+    if full_iters > start_iter:
+        iters.add(full_iters)
+    return iters
+
+
+def _is_stable_stage(stage: str) -> bool:
+    return stage == "stable" or stage.startswith("stable")
+
+
+def _expected_checkpoint_count(
+    stage: str,
+    tokens: int,
+    gbsz: int,
+    seq_length: int,
+    cooldown_decay_fraction: float,
+) -> int:
+    if _is_stable_stage(stage):
+        return len(_expected_stable_checkpoint_iters(
+            tokens, gbsz, seq_length, cooldown_decay_fraction
+        ))
+    return len(_expected_decay_checkpoint_iters(
+        tokens, gbsz, seq_length, cooldown_decay_fraction
+    ))
+
+
+def measure_all_checkpoint_storage_gb(
+    resolved_base: Path,
+    run_names: list[str],
+    *,
+    max_workers: int = 8,
+) -> dict[str, float | None]:
+    """Measure checkpoint storage for many runs in parallel (du -sb per run)."""
+    results: dict[str, float | None] = {}
+
+    def _du_one(name: str) -> tuple[str, float | None]:
+        ckpt_dir = resolved_base / name / "checkpoints"
+        return name, measure_checkpoint_storage_gb(ckpt_dir)
+
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = {pool.submit(_du_one, name): name for name in run_names}
+        for fut in as_completed(futures):
+            name, gb = fut.result()
+            results[name] = gb
+    return results
+
+
+def build_run_checkpoint_storage(
+    run_specs: list[tuple[str, str, int, str]],
+    run_to_gbsz: dict[str, int],
+    run_stage_map: dict[str, str],
+    resolved_base: Path,
+    rows: list[dict[str, Any]],
+    seq_length: int,
+    cooldown_decay_fraction: float,
+) -> dict[str, tuple[float | None, float | None]]:
+    """Per-run checkpoint storage in GiB: (measured_gb, remaining_gb).
+
+    measured_gb is the current ``checkpoints/`` size (du -sb) when present.
+    remaining_gb is an estimated storage still needed at completion, derived
+    from median GiB/checkpoint of finished runs and expected checkpoint count.
+    """
+    run_names = [name for name, _stage, _tok, _tier in run_specs]
+    measured_gb = measure_all_checkpoint_storage_gb(resolved_base, run_names)
+    iter_counts = {
+        name: _count_checkpoint_iters(resolved_base / name / "checkpoints")
+        for name in run_names
+    }
+
+    gb_per_ckpt_samples: list[float] = []
+    for run_name, _stage, _tok, _tier in run_specs:
+        gb = measured_gb.get(run_name)
+        n_ckpt = iter_counts.get(run_name, 0)
+        latest = next((r for r in reversed(rows) if r["run_name"] == run_name), None)
+        if (
+            gb is not None
+            and gb > 0
+            and n_ckpt > 0
+            and latest is not None
+            and latest.get("status_word") == "DONE"
+        ):
+            gb_per_ckpt_samples.append(gb / n_ckpt)
+
+    ref_gb_per_ckpt = median(gb_per_ckpt_samples) if gb_per_ckpt_samples else None
+
+    run_storage: dict[str, tuple[float | None, float | None]] = {}
+    for run_name, stage, tokens, _tier in run_specs:
+        gb = measured_gb.get(run_name)
+        n_ckpt = iter_counts.get(run_name, 0)
+        latest = next((r for r in reversed(rows) if r["run_name"] == run_name), None)
+        status = latest.get("status_word", "") if latest else ""
+
+        measured_val: float | None = (
+            gb if gb is not None and gb > 0 and n_ckpt > 0 else None
+        )
+
+        remaining_val: float | None = None
+        gbsz = run_to_gbsz.get(run_name)
+        if ref_gb_per_ckpt is not None and gbsz is not None:
+            exp_n = _expected_checkpoint_count(
+                stage, tokens, gbsz, seq_length, cooldown_decay_fraction
+            )
+            if exp_n > 0:
+                if status == "DONE" and measured_val is not None:
+                    remaining_val = None
+                else:
+                    remaining_ckpts = max(0, exp_n - n_ckpt)
+                    if remaining_ckpts > 0:
+                        remaining_val = ref_gb_per_ckpt * remaining_ckpts
+
+        run_storage[run_name] = (measured_val, remaining_val)
+
+    return run_storage
+
+
+CKPT_GB_PLACEHOLDER = "--"
+
+
+def _format_ckpt_measured_cell(
+    run_checkpoint_storage: dict[str, tuple[float | None, float | None]],
+    exp_name: str,
+    *,
+    compute: bool,
+    md: bool = False,
+) -> str:
+    if not compute:
+        return "" if md else CKPT_GB_PLACEHOLDER
+    measured, _remaining = run_checkpoint_storage.get(exp_name, (None, None))
+    if measured is None:
+        return CKPT_GB_PLACEHOLDER if not md else ""
+    return f"{measured:.1f}"
+
+
+def _format_ckpt_remaining_cell(
+    run_checkpoint_storage: dict[str, tuple[float | None, float | None]],
+    exp_name: str,
+    *,
+    compute: bool,
+    md: bool = False,
+) -> str:
+    if not compute:
+        return "" if md else CKPT_GB_PLACEHOLDER
+    _measured, remaining = run_checkpoint_storage.get(exp_name, (None, None))
+    if remaining is None:
+        return CKPT_GB_PLACEHOLDER if not md else ""
+    return f"{remaining:.1f}"
+
+
+def _format_ckpt_gb_total(total: float, *, compute: bool, md: bool = False) -> str:
+    if not compute:
+        return "" if md else CKPT_GB_PLACEHOLDER
+    return f"{total:.1f}" if total else CKPT_GB_PLACEHOLDER if not md else ""
 
 
 # ── SBATCH parsing ────────────────────────────────────────────────────────────
 
-
 def parse_sbatch(path: Path) -> tuple[int | None, int | None, int | None]:
     """Return (nodes, gpus_per_node, ckpt_step) from a job.sbatch file.
 
-    ckpt_step is the value of --ckpt-step, present only in decay jobs to
-    indicate the absolute iteration from which the decay phase starts.
+    ckpt_step is the value of --ckpt-step, present only in decay jobs to indicate
+    the absolute iteration from which the decay phase starts.
     """
     if not path.is_file():
         return None, None, None
@@ -276,14 +604,11 @@ def parse_sbatch(path: Path) -> tuple[int | None, int | None, int | None]:
 
 # ── Stdout log parsing ────────────────────────────────────────────────────────
 
-
 def parse_stdout(log_path: Path) -> dict:
-    """Parse a Megatron stdout log for training params, model size, and
-    iteration tracking.
+    """Parse a Megatron stdout log for training params, model size, and iteration tracking.
 
-    Throughput metrics (avg_tflop_per_gpu, avg_tok_per_gpu) are NOT
-    computed here; call load_or_compute_throughput() separately so
-    caching is applied consistently.
+    Throughput metrics (avg_tflop_per_gpu, avg_tok_per_gpu) are NOT computed here;
+    call load_or_compute_throughput() separately so caching is applied consistently.
     """
     result: dict[str, Any] = {
         "global_batch_size": None,
@@ -392,11 +717,14 @@ def parse_stdout(log_path: Path) -> dict:
         result["last_iter"] = iter_rows[-1][0]
         result["total_iters"] = iter_rows[-1][1]
 
+    # Infer submitting user from paths like /gpfs/projects/.../users/<name>/
+    m = re.search(r"/users/([^/\s]+)/", text)
+    result["log_user"] = m.group(1) if m else None
+
     return result
 
 
 # ── Stderr log parsing ────────────────────────────────────────────────────────
-
 
 def parse_stderr(log_path: Path) -> dict:
     """Parse stderr log for error patterns and wandb completion signal."""
@@ -405,6 +733,7 @@ def parse_stderr(log_path: Path) -> dict:
         "oom": False,
         "fatal": False,
         "time_limit": False,
+        "node_failure": False,
         "sigterm": False,
         "wandb_synced": False,
         "errors": [],
@@ -425,6 +754,9 @@ def parse_stderr(log_path: Path) -> dict:
         result["errors"].append("Fatal error")
     if RE_TIME_LIMIT.search(text):
         result["time_limit"] = True
+    if RE_NODE_FAILURE.search(text):
+        result["node_failure"] = True
+        result["errors"].append("Node failure")
     if RE_SIGTERM.search(text):
         result["sigterm"] = True
     if RE_WANDB_SUMMARY.search(text):
@@ -449,26 +781,18 @@ def _parse_sacct_ts(s: str) -> float | None:
 
 
 def query_sacct(job_ids: list[str]) -> dict[str, dict]:
-    """Query sacct for job state, elapsed time, GPU count, and start/end
-    timestamps.
-
-    Returns {} on error.
-    """
+    """Query sacct for job state, elapsed time, GPU count, and start/end timestamps.
+    Returns {} on error."""
     if not job_ids:
         return {}
     try:
         result = subprocess.run(
             [
-                "sacct",
-                "-j",
-                ",".join(job_ids),
-                "--format=JobID,State,Elapsed,AllocTRES%80,Start,End",
-                "--noheader",
-                "--parsable2",
+                "sacct", "-j", ",".join(job_ids),
+                "--format=JobID,State,Elapsed,AllocTRES%80,Start,End,User",
+                "--noheader", "--parsable2",
             ],
-            capture_output=True,
-            text=True,
-            timeout=15,
+            capture_output=True, text=True, timeout=15,
         )
         if result.returncode != 0:
             return {}
@@ -481,6 +805,7 @@ def query_sacct(job_ids: list[str]) -> dict[str, dict]:
         if len(parts) < 6:
             continue
         jid_field, state, elapsed, alloc_tres, start, end = parts[:6]
+        user = parts[6].strip() if len(parts) > 6 else ""
         if "." in jid_field:
             continue
         gpus = 0
@@ -488,11 +813,13 @@ def query_sacct(job_ids: list[str]) -> dict[str, dict]:
         if m:
             gpus = int(m.group(1))
         info[jid_field.strip()] = {
-            "state": state.strip(),
-            "elapsed": elapsed.strip(),
-            "gpus": gpus,
+            "state":    state.strip(),
+            "elapsed":  elapsed.strip(),
+            "gpus":     gpus,
             "start_ts": _parse_sacct_ts(start),
-            "end_ts": _parse_sacct_ts(end),
+            "end_ts":   _parse_sacct_ts(end),
+            "start_str": start.strip(),
+            "user":     user,
         }
     return info
 
@@ -513,8 +840,7 @@ def gpu_hours_from_timestamps(
 
 
 def load_external_gpu_h(csv_path: str) -> dict[tuple[str, str], float]:
-    """Load per-job GPU-h from a CSV previously produced by this script (--csv
-    output).
+    """Load per-job GPU-h from a CSV previously produced by this script (--csv output).
 
     Expects at minimum columns: Run, JobID, GPU-h.
     Returns {(run_name, job_id): gpu_hours}.  Rows with blank JobID are skipped.
@@ -524,8 +850,8 @@ def load_external_gpu_h(csv_path: str) -> dict[tuple[str, str], float]:
         reader = csv.DictReader(f)
         for row in reader:
             run_name = row.get("Run", "").strip()
-            job_id = row.get("JobID", "").strip()
-            gpu_h_s = row.get("GPU-h", "").strip()
+            job_id   = row.get("JobID", "").strip()
+            gpu_h_s  = row.get("GPU-h", "").strip()
             if not run_name or not job_id or not gpu_h_s:
                 continue
             try:
@@ -537,12 +863,13 @@ def load_external_gpu_h(csv_path: str) -> dict[tuple[str, str], float]:
 
 # ── Job discovery ─────────────────────────────────────────────────────────────
 
-
 def _run_id_sets(run_dir: Path) -> tuple[set[str], set[str]]:
     """Return (config_ids, log_ids) for a run directory.
 
     config_ids: IDs from config-{id}.yaml (job submitted via pipeline).
-    log_ids:    IDs from stdout/stderr-{id}.log (job actually ran).
+    log_ids:    IDs from stdout/stderr-{id}.log in logs/ subdirectory, OR
+                from slurm-{id}.log in run_dir when no logs/ subdirectory exists
+                (combined-log convention).  Mirrors the per-job fallback in main().
     A manually restarted run has log_ids that are not in config_ids (jobs
     submitted directly without the config-creation step).
     """
@@ -559,24 +886,28 @@ def _run_id_sets(run_dir: Path) -> tuple[set[str], set[str]]:
             m = re.match(r"(?:stdout|stderr)-(\d+)\.log$", f.name)
             if m:
                 log_ids.add(m.group(1))
+    else:
+        # Fallback: combined slurm-{id}.log files at run dir root
+        if run_dir.is_dir():
+            for f in run_dir.iterdir():
+                m = re.match(r"slurm-(\d+)\.log$", f.name)
+                if m:
+                    log_ids.add(m.group(1))
     return config_ids, log_ids
 
 
 def find_job_ids(run_dir: Path) -> list[str]:
-    """Return all Slurm job IDs found in logs/ or config-*.yaml files, sorted
-    ascending.
+    """Return all Slurm job IDs found in logs/ or config-*.yaml files, sorted ascending.
 
-    config-{id}.yaml is written at submission time; stdout/stderr logs
-    only appear once the job starts. Including config-based IDs lets us
-    detect jobs that are submitted (or queued) but haven't started
-    writing logs yet.
+    config-{id}.yaml is written at submission time; stdout/stderr logs only appear
+    once the job starts. Including config-based IDs lets us detect jobs that are
+    submitted (or queued) but haven't started writing logs yet.
     """
     config_ids, log_ids = _run_id_sets(run_dir)
     return sorted(config_ids | log_ids)
 
 
 # ── Token budget from run name ─────────────────────────────────────────────────
-
 
 def extract_token_budget(run_name: str) -> str:
     m = RE_BUDGET.search(run_name)
@@ -586,7 +917,6 @@ def extract_token_budget(run_name: str) -> str:
 
 
 # ── Monitor-state loading ─────────────────────────────────────────────────────
-
 
 def load_run_monitor_events(run_name: str, monitor_dirs: list[Path]) -> list[dict] | None:
     """Load all monitor-state sessions for *run_name* from *monitor_dirs*.
@@ -610,21 +940,17 @@ def load_run_monitor_events(run_name: str, monitor_dirs: list[Path]) -> list[dic
                 parts = key.split(":")
                 # key format: "log:<event_name>:<log_events_index>"
                 if len(parts) >= 2 and parts[0] == "log":
-                    events.append(
-                        {
-                            "name": parts[1],
-                            "ts": val.get("last_action_ts"),
-                        }
-                    )
-            sessions.append(
-                {
-                    "session_id": d.name,
-                    "events": events,
-                    "last_status": rt.get("last_status"),
-                    "final_state": rt.get("final_state"),
-                    "runtime_job_id": rt.get("runtime_job_id"),
-                }
-            )
+                    events.append({
+                        "name": parts[1],
+                        "ts":   val.get("last_action_ts"),
+                    })
+            sessions.append({
+                "session_id":     d.name,
+                "events":         events,
+                "last_status":    rt.get("last_status"),
+                "final_state":    rt.get("final_state"),
+                "runtime_job_id": rt.get("runtime_job_id"),
+            })
     return sessions if sessions else None
 
 
@@ -633,8 +959,7 @@ def map_events_to_jobs(
     sacct_info: dict[str, dict],
     monitor_sessions: list[dict],
 ) -> dict[str, set[str]]:
-    """Assign monitor-state events to specific Slurm job IDs via sacct
-    timestamps.
+    """Assign monitor-state events to specific Slurm job IDs via sacct timestamps.
 
     For each event's ``last_action_ts``, we find the job whose sacct time window
     [Start, End + _EVENT_MATCH_TOLERANCE_S] contains the timestamp.
@@ -645,7 +970,10 @@ def map_events_to_jobs(
     job_events: dict[str, set[str]] = {jid: set() for jid in job_ids}
 
     all_events = [
-        ev for session in monitor_sessions for ev in session["events"] if ev.get("ts") is not None
+        ev
+        for session in monitor_sessions
+        for ev in session["events"]
+        if ev.get("ts") is not None
     ]
     if not all_events:
         return job_events
@@ -653,7 +981,7 @@ def map_events_to_jobs(
     for job_id in job_ids:
         sacct = sacct_info.get(job_id, {})
         start_ts = sacct.get("start_ts")
-        end_ts = sacct.get("end_ts")
+        end_ts   = sacct.get("end_ts")
         if start_ts is None:
             continue
         deadline = (end_ts if end_ts is not None else float("inf")) + _EVENT_MATCH_TOLERANCE_S
@@ -666,7 +994,6 @@ def map_events_to_jobs(
 
 # ── Status determination ──────────────────────────────────────────────────────
 
-
 def _compute_restart_action(
     job_id: str,
     job_has_config: bool,
@@ -675,8 +1002,7 @@ def _compute_restart_action(
     run_config_ids: set[str],
     run_log_ids: set[str],
 ) -> str:
-    """Return the restart action for a failed/cancelled job based on what
-    followed it.
+    """Return the restart action for a failed/cancelled job based on what followed it.
 
     Looks at the next job in sequence that actually ran (has logs) and classifies:
       AUTO_RESTARTED:    next running job has a config  (normal autoexp restart)
@@ -696,7 +1022,7 @@ def _compute_restart_action(
         return "NONE"
     # Find the next job that actually ran (has a log file)
     next_running: str | None = None
-    for later_id in all_job_ids[idx + 1 :]:
+    for later_id in all_job_ids[idx + 1:]:
         if later_id in run_log_ids:
             next_running = later_id
             break
@@ -719,7 +1045,8 @@ def determine_status(
     run_config_ids: set[str] | None = None,
     run_log_ids: set[str] | None = None,
 ) -> tuple[str, str, str, str]:
-    """Returns (emoji, status_word, error_description, action_word).
+    """
+    Returns (emoji, status_word, error_description, action_word).
 
     Status words:  NOT_LAUNCHED | QUEUED | DONE | FAILED | CANCELLED | TRAINING
     Action words:  AUTO_RESTARTED | MANUALLY_RESTARTED | NEW_SESSION | NONE | ""
@@ -738,29 +1065,29 @@ def determine_status(
     sacct_state = sacct.get("state", "")
 
     # Pre-compute restart action (used for all FAILED/CANCELLED paths below)
-    _cfg_ids = run_config_ids if run_config_ids is not None else set()
-    _log_ids = run_log_ids if run_log_ids is not None else set()
-    _has_cfg = job_id in _cfg_ids
-    _restart = _compute_restart_action(
-        job_id, _has_cfg, is_latest_job, all_job_ids, _cfg_ids, _log_ids
-    )
+    _cfg_ids  = run_config_ids if run_config_ids is not None else set()
+    _log_ids  = run_log_ids    if run_log_ids    is not None else set()
+    _has_cfg  = job_id in _cfg_ids
+    _restart  = _compute_restart_action(job_id, _has_cfg, is_latest_job, all_job_ids, _cfg_ids, _log_ids)
 
     # ── Classify events from monitor state (primary) or stderr (fallback) ────
     use_monitor = job_monitor_events is not None
     if use_monitor:
-        triggered_hard = job_monitor_events & _HARD_ERROR_EVENTS
+        triggered_hard  = job_monitor_events & _HARD_ERROR_EVENTS
         triggered_clean = job_monitor_events & _CLEAN_RESTART_EVENTS
-        triggered_done = job_monitor_events & _FINISH_EVENTS
-        hard_error_desc = "; ".join(_EVENT_ERROR_DESC.get(n, n) for n in sorted(triggered_hard))
+        triggered_done  = job_monitor_events & _FINISH_EVENTS
+        hard_error_desc = "; ".join(
+            _EVENT_ERROR_DESC.get(n, n) for n in sorted(triggered_hard)
+        )
     else:
         # stderr-derived booleans (legacy path)
-        triggered_hard = set()
+        triggered_hard  = set()
         triggered_clean = set()
-        triggered_done = set()
+        triggered_done  = set()
         hard_error_desc = ""
 
     # ── DONE ─────────────────────────────────────────────────────────────────
-    last_iter = stdout_data.get("last_iter")
+    last_iter   = stdout_data.get("last_iter")
     train_iters = stdout_data.get("train_iters")
     if last_iter is not None and train_iters is not None and last_iter >= train_iters:
         return "✅", "DONE", "", ""
@@ -780,6 +1107,8 @@ def determine_status(
             return "⚠️", "FAILED", "Out of memory (CUDA OOM)", _restart
         if stderr_data.get("fatal"):
             return "⚠️", "FAILED", "Fatal error", _restart
+        if stderr_data.get("node_failure"):
+            return "⚠️", "FAILED", "Node failure", _restart
 
     # ── sacct-based states ────────────────────────────────────────────────────
     if sacct_state:
@@ -797,6 +1126,8 @@ def determine_status(
             return "🕒", "QUEUED", "", ""
         if sacct_state == "TIMEOUT":
             return "⚠️", "FAILED", "Time limit exceeded", _restart
+        if sacct_state == "NODE_FAIL":
+            return "⚠️", "FAILED", "Node failure", _restart
 
     # ── No stdout → queued / not started ─────────────────────────────────────
     if stdout_data.get("last_iter") is None and stdout_data.get("train_iters") is None:
@@ -819,9 +1150,7 @@ def determine_status(
     return "⚠️", "FAILED", error_str, _restart
 
 
-def compute_progress(
-    last_iter: int | None, ckpt_step: int | None, total_iters: int | None
-) -> float | None:
+def compute_progress(last_iter: int | None, ckpt_step: int | None, total_iters: int | None) -> float | None:
     """Return training progress [0–100] for a single training phase.
 
     ckpt_step is the absolute iteration where training started (0 for stable runs,
@@ -840,7 +1169,6 @@ def compute_progress(
 
 
 # ── Main ──────────────────────────────────────────────────────────────────────
-
 
 def main() -> None:
     ap = argparse.ArgumentParser(
@@ -899,6 +1227,21 @@ def main() -> None:
             "If omitted, auto-discovered from <project_root>/monitor_state/*/ ."
         ),
     )
+    ap.add_argument(
+        "--compute-storage",
+        action="store_true",
+        help=(
+            "Measure checkpoint storage (du -sb on each run's checkpoints/ directory). "
+            "Slow on large trees; without this flag the Ckpt-GB columns are left blank."
+        ),
+    )
+    ap.add_argument(
+        "--machine",
+        default="LEO",
+        help="Local cluster name tag (e.g. LEO, MN5). Jobs on this cluster are tagged "
+             "using this value; foreign-cluster jobs detected via sacct collision are "
+             "tagged with the opposite name. Default: %(default)s",
+    )
     args = ap.parse_args()
 
     project_root = Path(__file__).resolve().parent.parent
@@ -908,7 +1251,8 @@ def main() -> None:
     if args.monitor_dirs is None:
         monitor_root = project_root / "monitor_state"
         monitor_dirs: list[Path] = (
-            sorted(p for p in monitor_root.iterdir() if p.is_dir()) if monitor_root.is_dir() else []
+            sorted(p for p in monitor_root.iterdir() if p.is_dir())
+            if monitor_root.is_dir() else []
         )
     else:
         monitor_dirs = [Path(d) for d in args.monitor_dirs]
@@ -918,6 +1262,16 @@ def main() -> None:
     seed = cfg["seed"]
     combos = cfg["combos"]
     tok_to_stage = cfg["tok_to_stage"]
+    adam_beta2 = cfg.get("adam_beta2", 0.95)
+
+    def _render(stage: str, lr: float, gbsz: int, stable_tok: int | None = None) -> str:
+        """render_job_name wrapper that also substitutes adam_beta2 and similar extras.
+
+        render_job_name leaves un-substituted keys as '\\${key}' (backslash kept),
+        so we must match the same prefix when replacing.
+        """
+        raw = render_job_name(cfg["job_name_tpl"], 1, lr, gbsz, seed, stage, stable_tok)
+        return raw.replace("\\${backend.megatron.adam_beta2}", str(adam_beta2))
 
     # Remap cluster path to local mount
     if args.results_dir is None:
@@ -929,16 +1283,21 @@ def main() -> None:
 
     # Build list of (run_name, stage, tokens) applying the per-combo filter.
     # For each combo:
-    #   - stable: always 1 run  → ..._stable{max_tokens_BT}BT
+    #   - stable: always 1 run  → ..._stable{max_tokens_BT}BT  (or ..._stable12BT for new format)
     #   - decays: only token budgets in (center | cross | diagonal) token sets
     run_specs: list[tuple[str, str, int, str]] = []
+    decay_to_stable: dict[str, str] = {}  # decay run_name → its paired stable run_name
+    run_to_gbsz: dict[str, int] = {}
     for combo in combos:
         lr, gbsz = combo["lr"], combo["gbsz"]
         stable_tok = combo["stable_tokens"]
         valid_decay_toks = combo["valid_decay_tokens"]
 
-        name = render_job_name(cfg["job_name_tpl"], 1, lr, gbsz, seed, "stable", stable_tok)
-        run_specs.append((name, "stable", stable_tok, combo["stable_launch_tier"]))
+        # New format: stable_stage_name is the full name (e.g. "stable12BT"); old format: None.
+        stable_stage = combo.get("stable_stage_name") or "stable"
+        stable_name = _render(stable_stage, lr, gbsz, stable_tok if stable_stage == "stable" else None)
+        run_specs.append((stable_name, "stable", stable_tok, combo["stable_launch_tier"]))
+        run_to_gbsz[stable_name] = gbsz
 
         # Decay runs: only the token budgets permitted by the filter
         for decay_tok in sorted(valid_decay_toks):
@@ -951,19 +1310,22 @@ def main() -> None:
                 tier = "cross"
             else:
                 tier = "diagonal"
-            name = render_job_name(cfg["job_name_tpl"], 1, lr, gbsz, seed, stage_name)
+            name = _render(stage_name, lr, gbsz)
             run_specs.append((name, stage_name, decay_tok, tier))
+            decay_to_stable[name] = stable_name
+            run_to_gbsz[name] = gbsz
+
+    run_tier_map: dict[str, str] = {name: tier for name, _stage, _tok, tier in run_specs}
+    run_stage_map: dict[str, str] = {name: stage for name, stage, _tok, _tier in run_specs}
 
     # Resolve the local results base directory (template typically has no per-combo vars here)
     sample_ctx: dict[str, Any] = {"backend.megatron.seed": seed}
     if combos:
-        sample_ctx.update(
-            {
-                "backend.megatron.global_batch_size": combos[0]["gbsz"],
-                "backend.megatron.num_experts": 1,
-                "backend.megatron.lr": combos[0]["lr"],
-            }
-        )
+        sample_ctx.update({
+            "backend.megatron.global_batch_size": combos[0]["gbsz"],
+            "backend.megatron.num_experts": 1,
+            "backend.megatron.lr": combos[0]["lr"],
+        })
     resolved_base = Path(_subst(local_template, sample_ctx))
     if not resolved_base.is_dir():
         resolved_base = Path(local_template)
@@ -978,18 +1340,14 @@ def main() -> None:
         all_job_ids.extend(jids)
 
     sacct_info = query_sacct(all_job_ids)
-    # sacct_available = bool(sacct_info) or bool(
-    #     all_job_ids
-    # )  # mark as available if sacct returned anything
+    sacct_available = bool(sacct_info) or bool(all_job_ids)  # mark as available if sacct returned anything
 
     # If sacct is unavailable and --csv points to an existing file, read back the
     # GPU-h column from that file so the values are preserved when it is rewritten.
     external_job_gpu_h: dict[tuple[str, str], float] = {}
     if not sacct_info and args.csv and Path(args.csv).is_file():
         external_job_gpu_h = load_external_gpu_h(args.csv)
-        print(
-            f"sacct unavailable – loaded {len(external_job_gpu_h)} per-job GPU-h entries from {args.csv}"
-        )
+        print(f"sacct unavailable – loaded {len(external_job_gpu_h)} per-job GPU-h entries from {args.csv}")
 
     # Load monitor-state events for every run and map them to Slurm job IDs.
     # run_monitor_sessions[run_name] = None  → no monitor state (use stderr fallback)
@@ -1040,52 +1398,60 @@ def main() -> None:
             else:
                 # Run directory doesn't exist → this tier has not been launched at all
                 s_emoji, s_word = "⚪", "NOT_LAUNCHED"
-            rows.append(
-                {
-                    "run_name": run_name,
-                    "job_id": "",
-                    "stage": stage,
-                    "tier": tier,
-                    "token_budget": token_budget,
-                    "tokens_b": tokens / 1e9,
-                    "nodes": sbatch_nodes,
-                    "transformer_params_b": None,
-                    "total_params_b": None,
-                    "global_batch_size": None,
-                    "lr": None,
-                    "micro_batch_size": None,
-                    "num_workers": None,
-                    "ttfi_min": None,
-                    "ttfi_gpu_h": None,
-                    "train_iters": None,
-                    "last_iter": None,
-                    "progress": None,
-                    "last_train_loss": None,
-                    "last_val_loss": None,
-                    "last_ckpt": last_ckpt,
-                    "avg_tflop_per_gpu": None,
-                    "avg_tok_per_gpu": None,
-                    "n_iters_sampled": None,
-                    "gpu_hours": None,
-                    "time_lost_h": None,
-                    "gpu_h_lost": None,
-                    "overhead_time_h": None,
-                    "overhead_gpu_h": None,
-                    "overhead_pct": None,
-                    "sacct_state": "",
-                    "sacct_elapsed": "",
-                    "status_emoji": s_emoji,
-                    "status_word": s_word,
-                    "action_word": "",
-                    "error_desc": "",
-                }
-            )
+            rows.append({
+                "run_name": run_name,
+                "job_id": "",
+                "stage": stage,
+                "tier": tier,
+                "token_budget": token_budget,
+                "tokens_b": tokens / 1e9,
+                "nodes": sbatch_nodes,
+                "transformer_params_b": None,
+                "total_params_b": None,
+                "global_batch_size": None,
+                "lr": None,
+                "micro_batch_size": None,
+                "num_workers": None,
+                "ttfi_min": None,
+                "ttfi_gpu_h": None,
+                "train_iters": None,
+                "last_iter": None,
+                "ckpt_step": sbatch_ckpt_step,
+                "progress": None,
+                "last_train_loss": None,
+                "last_val_loss": None,
+                "last_ckpt": last_ckpt,
+                "avg_tflop_per_gpu": None,
+                "avg_tok_per_gpu": None,
+                "n_iters_sampled": None,
+                "gpu_hours": None,
+                "time_lost_h": None,
+                "gpu_h_lost": None,
+                "overhead_time_h": None,
+                "overhead_gpu_h": None,
+                "overhead_pct": None,
+                "sacct_state": "",
+                "sacct_elapsed": "",
+                "sacct_start_str": "",
+                "owner": "",
+                "cluster": "",
+                "status_emoji": s_emoji,
+                "status_word": s_word,
+                "action_word": "",
+                "error_desc": "",
+            })
             continue
 
         for job_id in job_ids:
             logs_dir = run_dir / "logs"
             stdout_log = logs_dir / f"stdout-{job_id}.log"
             stderr_log = logs_dir / f"stderr-{job_id}.log"
+            # Fallback: some sweeps write a combined slurm-{id}.log in the run dir
+            if not stdout_log.is_file():
+                slurm_log = run_dir / f"slurm-{job_id}.log"
+                if slurm_log.is_file():
+                    stdout_log = slurm_log
+                    stderr_log = slurm_log
             is_latest = job_id == job_ids[-1]
 
             stdout_data = parse_stdout(stdout_log)
@@ -1124,6 +1490,30 @@ def main() -> None:
             elif (run_name, job_id) in external_job_gpu_h:
                 gpu_hours = external_job_gpu_h[(run_name, job_id)]
 
+            # Cross-cluster collision detection:
+            # MN5 and Leonardo share a numeric Slurm job ID space.  A job ID from
+            # MN5 that also exists on Leonardo as a different job returns wrong
+            # timestamps and GPU counts.  Two heuristics:
+            #   1. sacct reports 0 GPUs but sbatch declares GPUs → CPU-only collision
+            #   2. sacct reports GPUs but fewer than half of what sbatch declares →
+            #      a different user's small job collided (e.g. 1 GPU vs expected 32)
+            _sacct_gpus = sacct_entry.get("gpus", 0)
+            _is_collision = (
+                (sacct_entry and _sacct_gpus == 0 and total_gpus > 0)
+                or (sacct_entry and total_gpus > 0 and 0 < _sacct_gpus < total_gpus // 2)
+            )
+            cluster = ""
+            if _is_collision:
+                foreign = "MN5" if args.machine != "MN5" else "LEO"
+                cluster = foreign
+                sacct_entry = {}
+                sacct_state = ""
+                sacct_elapsed = ""
+                gpu_hours = external_job_gpu_h.get((run_name, job_id))
+                gpus = total_gpus
+            elif sacct_entry:
+                cluster = args.machine
+
             # Low-throughput analysis (reuses the throughput cache written above).
             _job_lt = _analyze_low_throughput_job(
                 stdout_log,
@@ -1142,6 +1532,15 @@ def main() -> None:
             sacct_start = sacct_entry.get("start_ts")
             sacct_end = sacct_entry.get("end_ts")
             first_iter_ts = stdout_data.get("first_iter_ts")
+            # Validate first_iter_ts against the sacct time window: if the log
+            # timestamp falls outside [start-60s, end+300s] the log was written by
+            # a different job (stale filename or cross-cluster log mismatch).
+            if (first_iter_ts is not None
+                    and sacct_start is not None
+                    and sacct_end is not None):
+                _ts = first_iter_ts.timestamp()
+                if _ts < sacct_start - 60 or _ts > sacct_end + 300:
+                    first_iter_ts = None
             if sacct_start is not None and first_iter_ts is not None:
                 ttfi_min = (first_iter_ts.timestamp() - sacct_start) / 60.0
             elif sacct_start is not None and first_iter_ts is None and sacct_end is not None:
@@ -1149,107 +1548,115 @@ def main() -> None:
             elif first_iter_ts is None and gpu_hours is not None and total_gpus > 0:
                 ttfi_min = (gpu_hours / total_gpus) * 60.0
             ttfi_gpu_h: float | None = (
-                (ttfi_min / 60.0) * total_gpus if ttfi_min is not None and total_gpus > 0 else None
+                (ttfi_min / 60.0) * total_gpus
+                if ttfi_min is not None and total_gpus > 0
+                else None
             )
 
+            # Sanity check: TTFI cannot physically exceed total job elapsed time.
+            # If it does, the timestamps belong to a different job (cross-cluster
+            # collision where sacct returned a Leo job with the same ID and GPUs).
+            if ttfi_gpu_h is not None and gpu_hours is not None and ttfi_gpu_h > gpu_hours:
+                ttfi_min = None
+                ttfi_gpu_h = None
+
             # Total overhead = TTFI + low-throughput (both in hours / GPU-h)
-            _lt_time_v = _job_lt.get("time_lost_h")
+            _lt_time_v  = _job_lt.get("time_lost_h")
             _lt_gpu_h_v = _job_lt.get("gpu_h_lost")
             overhead_time_h: float | None = (
                 (ttfi_min / 60.0 if ttfi_min is not None else 0.0) + (_lt_time_v or 0.0)
-                if ttfi_min is not None or _lt_time_v is not None
-                else None
+                if ttfi_min is not None or _lt_time_v is not None else None
             )
             overhead_gpu_h: float | None = (
                 (ttfi_gpu_h or 0.0) + (_lt_gpu_h_v or 0.0)
-                if ttfi_gpu_h is not None or _lt_gpu_h_v is not None
-                else None
+                if ttfi_gpu_h is not None or _lt_gpu_h_v is not None else None
             )
+            # Sanity check: overhead cannot exceed total job GPU-h.  If it does,
+            # the LowTP analysis read a longer log than the actual job duration
+            # (cross-cluster log collision, same job ID sharing a log file).
+            if overhead_gpu_h is not None and gpu_hours is not None and overhead_gpu_h > gpu_hours:
+                overhead_time_h = None
+                overhead_gpu_h  = None
             overhead_pct: float | None = (
                 overhead_gpu_h / gpu_hours * 100.0
-                if overhead_gpu_h is not None and gpu_hours and gpu_hours > 0
-                else None
+                if overhead_gpu_h is not None and gpu_hours and gpu_hours > 0 else None
             )
 
             # Per-job monitor events: set[str] if monitor state exists, else None
             job_events_map = run_job_monitor_events.get(run_name)
             job_monitor_events = (
-                job_events_map.get(job_id)  # may be empty set
+                job_events_map.get(job_id)   # may be empty set
                 if job_events_map is not None
-                else None  # no monitor state → use stderr
+                else None                     # no monitor state → use stderr
             )
 
             emoji, status_word, error_desc, action_word = determine_status(
-                job_id,
-                job_ids,
-                stdout_data,
-                stderr_data,
-                sacct_info,
-                is_latest,
+                job_id, job_ids, stdout_data, stderr_data, sacct_info, is_latest,
                 job_monitor_events=job_monitor_events,
                 run_config_ids=run_config_ids,
                 run_log_ids=run_log_ids,
             )
 
-            rows.append(
-                {
-                    "run_name": run_name,
-                    "job_id": job_id,
-                    "stage": stage,
-                    "token_budget": token_budget,
-                    "tokens_b": tokens / 1e9,
-                    "tier": tier,
-                    "nodes": sbatch_nodes,
-                    "transformer_params_b": stdout_data.get("transformer_params_b"),
-                    "total_params_b": stdout_data.get("total_params_b"),
-                    "global_batch_size": stdout_data.get("global_batch_size"),
-                    "lr": stdout_data.get("lr"),
-                    "micro_batch_size": stdout_data.get("micro_batch_size"),
-                    "num_workers": stdout_data.get("num_workers"),
-                    "ttfi_min": ttfi_min,
-                    "ttfi_gpu_h": ttfi_gpu_h,
-                    "train_iters": stdout_data.get("train_iters"),
-                    "last_iter": stdout_data.get("last_iter"),
-                    "progress": compute_progress(
-                        stdout_data.get("last_iter"),
-                        sbatch_ckpt_step,
-                        stdout_data.get("total_iters"),
-                    ),
-                    "last_train_loss": stdout_data.get("last_train_loss"),
-                    "last_val_loss": stdout_data.get("last_val_loss"),
-                    "last_ckpt": last_ckpt,
-                    "avg_tflop_per_gpu": _tp["avg_tflop_per_gpu"] if _tp else None,
-                    "avg_tok_per_gpu": _tp["avg_tok_per_gpu"] if _tp else None,
-                    "n_iters_sampled": _tp["n_iters"] if _tp else None,
-                    "gpu_hours": gpu_hours,
-                    "time_lost_h": _job_lt.get("time_lost_h"),
-                    "gpu_h_lost": _job_lt.get("gpu_h_lost"),
-                    "overhead_time_h": overhead_time_h,
-                    "overhead_gpu_h": overhead_gpu_h,
-                    "overhead_pct": overhead_pct,
-                    "sacct_state": sacct_state,
-                    "sacct_elapsed": sacct_elapsed,
-                    "status_emoji": emoji,
-                    "status_word": status_word,
-                    "action_word": action_word,
-                    "error_desc": error_desc,
-                }
+            _progress = compute_progress(
+                stdout_data.get("last_iter"),
+                sbatch_ckpt_step,
+                stdout_data.get("total_iters"),
             )
+            if _progress is not None and _progress >= 100.0 and status_word != "DONE":
+                emoji, status_word, error_desc, action_word = "✅", "DONE", "", ""
+
+            rows.append({
+                "run_name": run_name,
+                "job_id": job_id,
+                "stage": stage,
+                "token_budget": token_budget,
+                "tokens_b": tokens / 1e9,
+                "tier": tier,
+                "nodes": sbatch_nodes,
+                "transformer_params_b": stdout_data.get("transformer_params_b"),
+                "total_params_b": stdout_data.get("total_params_b"),
+                "global_batch_size": stdout_data.get("global_batch_size"),
+                "lr": stdout_data.get("lr"),
+                "micro_batch_size": stdout_data.get("micro_batch_size"),
+                "num_workers": stdout_data.get("num_workers"),
+                "ttfi_min": ttfi_min,
+                "ttfi_gpu_h": ttfi_gpu_h,
+                "train_iters": stdout_data.get("train_iters"),
+                "last_iter": stdout_data.get("last_iter"),
+                "ckpt_step": sbatch_ckpt_step,
+                "progress": _progress,
+                "last_train_loss": stdout_data.get("last_train_loss"),
+                "last_val_loss": stdout_data.get("last_val_loss"),
+                "last_ckpt": last_ckpt,
+                "avg_tflop_per_gpu": _tp["avg_tflop_per_gpu"] if _tp else None,
+                "avg_tok_per_gpu": _tp["avg_tok_per_gpu"] if _tp else None,
+                "n_iters_sampled": _tp["n_iters"] if _tp else None,
+                "gpu_hours": gpu_hours,
+                "time_lost_h": _job_lt.get("time_lost_h"),
+                "gpu_h_lost": _job_lt.get("gpu_h_lost"),
+                "overhead_time_h": overhead_time_h,
+                "overhead_gpu_h": overhead_gpu_h,
+                "overhead_pct": overhead_pct,
+                "sacct_state": sacct_state,
+                "sacct_elapsed": sacct_elapsed,
+                "sacct_start_str": sacct_entry.get("start_str", ""),
+                # sacct user for local jobs; fall back to path-based inference
+                # from log for foreign-cluster jobs (sacct entry is discarded).
+                "owner": sacct_entry.get("user", "") or stdout_data.get("log_user", "") or "",
+                "cluster": cluster,
+                "status_emoji": emoji,
+                "status_word": status_word,
+                "action_word": action_word,
+                "error_desc": error_desc,
+            })
 
     # ── Fill-forward static fields for eval-only runs ───────────────────────
     # Fields that are constant per run but may be absent from an eval-only log
     # (Megatron may not print the full args/param-count block in eval mode).
     _FILL_FIELDS = [
-        "transformer_params_b",
-        "total_params_b",
-        "global_batch_size",
-        "lr",
-        "micro_batch_size",
-        "num_workers",
-        "train_iters",
-        "avg_tflop_per_gpu",
-        "avg_tok_per_gpu",
-        "last_train_loss",
+        "transformer_params_b", "total_params_b", "global_batch_size", "lr",
+        "micro_batch_size", "num_workers", "train_iters",
+        "avg_tflop_per_gpu", "avg_tok_per_gpu", "last_train_loss",
     ]
     _run_last_known: dict[str, dict[str, Any]] = {}
     for r in rows:
@@ -1260,6 +1667,11 @@ def main() -> None:
                 r[fld] = known[fld]
             if r.get(fld) is not None:
                 known[fld] = r[fld]
+        # Track last known iter/progress for QUEUED fill-forward below.
+        if r.get("last_iter") is not None:
+            known["last_iter"] = r["last_iter"]
+        if r.get("progress") is not None:
+            known["progress"] = r["progress"]
         # After filling train_iters, recompute progress if last_iter is still None
         # but the checkpoint confirms training completed.
         if r.get("last_iter") is None and r.get("last_ckpt") is not None:
@@ -1267,6 +1679,24 @@ def main() -> None:
             if ti is not None and r["last_ckpt"] >= ti:
                 r["last_iter"] = ti
                 r["progress"] = 100.0
+
+    # For QUEUED rows with no progress, carry forward last_iter/progress from the
+    # previous job of the same run: a queued job hasn't started yet so its progress
+    # is the same as where the previous job left off.
+    _run_queued_known: dict[str, dict[str, Any]] = {}
+    for r in rows:
+        rn = r["run_name"]
+        known = _run_queued_known.setdefault(rn, {})
+        if r["status_word"] == "QUEUED" and r.get("last_iter") is None:
+            if "last_iter" in known:
+                r["last_iter"] = known["last_iter"]
+            if "progress" in known:
+                r["progress"] = known["progress"]
+        else:
+            if r.get("last_iter") is not None:
+                known["last_iter"] = r["last_iter"]
+            if r.get("progress") is not None:
+                known["progress"] = r["progress"]
 
     # ── Print table ─────────────────────────────────────────────────────────
 
@@ -1311,6 +1741,7 @@ def main() -> None:
         f"{'Overhead-GPU-h':>14} "
         f"{'GPU-h':>10} "
         f"{'Overhead%':>9} "
+        f"{'Cluster':>7} "
         f"{'Emoji':>2} "
         f"{'Status':>12} "
         f"{'Action':>14} "
@@ -1327,17 +1758,17 @@ def main() -> None:
 
     _RESTART_ACTIONS = {"AUTO_RESTARTED", "MANUALLY_RESTARTED", "NEW_SESSION"}
     status_colors = {
-        "DONE": "\033[92m",
-        "TRAINING": "\033[94m",
-        "FAILED": "\033[91m",
-        "FAILED+AUTO_RESTARTED": "\033[33m",
-        "FAILED+MANUALLY_RESTARTED": "\033[35m",
-        "FAILED+NEW_SESSION": "\033[36m",
-        "CANCELLED": "\033[91m",
-        "CANCELLED+MANUALLY_RESTARTED": "\033[35m",
-        "CANCELLED+NEW_SESSION": "\033[36m",
-        "QUEUED": "\033[93m",
-        "NOT_LAUNCHED": "\033[90m",
+        "DONE":                           "\033[92m",
+        "TRAINING":                       "\033[94m",
+        "FAILED":                         "\033[91m",
+        "FAILED+AUTO_RESTARTED":          "\033[33m",
+        "FAILED+MANUALLY_RESTARTED":      "\033[35m",
+        "FAILED+NEW_SESSION":             "\033[36m",
+        "CANCELLED":                      "\033[91m",
+        "CANCELLED+MANUALLY_RESTARTED":   "\033[35m",
+        "CANCELLED+NEW_SESSION":          "\033[36m",
+        "QUEUED":                         "\033[93m",
+        "NOT_LAUNCHED":                   "\033[90m",
     }
     RESET = "\033[0m"
 
@@ -1354,36 +1785,28 @@ def main() -> None:
             color_key = r["status_word"]
         color = status_colors.get(color_key, "")
 
-        tflop_str = f"{r['avg_tflop_per_gpu']:.1f}" if r["avg_tflop_per_gpu"] is not None else "N/A"
-        tok_str = f"{r['avg_tok_per_gpu']:.0f}" if r["avg_tok_per_gpu"] is not None else "N/A"
-        gpu_h_str = f"{r['gpu_hours']:.1f}" if r["gpu_hours"] is not None else "N/A"
-        lt_time_str = f"{r['time_lost_h']:.3f}" if r.get("time_lost_h") is not None else "N/A"
-        lt_gpu_h_str = f"{r['gpu_h_lost']:.2f}" if r.get("gpu_h_lost") is not None else "N/A"
-        trans_str = (
-            f"{r['transformer_params_b']:.2f}" if r["transformer_params_b"] is not None else "N/A"
-        )
+        tflop_str    = f"{r['avg_tflop_per_gpu']:.1f}" if r["avg_tflop_per_gpu"] is not None else "N/A"
+        tok_str      = f"{r['avg_tok_per_gpu']:.0f}"  if r["avg_tok_per_gpu"]   is not None else "N/A"
+        gpu_h_str    = f"{r['gpu_hours']:.1f}"        if r["gpu_hours"]         is not None else "N/A"
+        lt_time_str  = f"{r['time_lost_h']:.3f}"      if r.get("time_lost_h")   is not None else "N/A"
+        lt_gpu_h_str = f"{r['gpu_h_lost']:.2f}"       if r.get("gpu_h_lost")    is not None else "N/A"
+        trans_str = f"{r['transformer_params_b']:.2f}" if r["transformer_params_b"] is not None else "N/A"
         total_str = f"{r['total_params_b']:.2f}" if r["total_params_b"] is not None else "N/A"
         lr_str = f"{r['lr']:.4f}" if r["lr"] is not None else "N/A"
         ckpt_str = str(r["last_ckpt"]) if r["last_ckpt"] is not None else "N/A"
         ti_str = str(r["train_iters"]) if r["train_iters"] is not None else "N/A"
         ci_str = str(r["last_iter"]) if r.get("last_iter") is not None else "N/A"
         prog_str = f"{r['progress']:.1f}%" if r.get("progress") is not None else "N/A"
-        trn_loss_str = (
-            f"{r['last_train_loss']:.4f}" if r.get("last_train_loss") is not None else "N/A"
-        )
+        trn_loss_str = f"{r['last_train_loss']:.4f}" if r.get("last_train_loss") is not None else "N/A"
         val_loss_str = f"{r['last_val_loss']:.4f}" if r.get("last_val_loss") is not None else "N/A"
         gbs_str = str(r["global_batch_size"]) if r["global_batch_size"] is not None else "N/A"
         mbs_str = str(r["micro_batch_size"]) if r["micro_batch_size"] is not None else "N/A"
         wkr_str = str(r["num_workers"]) if r["num_workers"] is not None else "N/A"
-        ttfi_str = f"{r['ttfi_min']:.1f}" if r.get("ttfi_min") is not None else "N/A"
-        ttfi_gpu_h_str = f"{r['ttfi_gpu_h']:.2f}" if r.get("ttfi_gpu_h") is not None else "N/A"
-        oh_time_str = (
-            f"{r['overhead_time_h']:.3f}" if r.get("overhead_time_h") is not None else "N/A"
-        )
-        oh_gpu_h_str = (
-            f"{r['overhead_gpu_h']:.2f}" if r.get("overhead_gpu_h") is not None else "N/A"
-        )
-        oh_pct_str = f"{r['overhead_pct']:.1f}%" if r.get("overhead_pct") is not None else "N/A"
+        ttfi_str       = f"{r['ttfi_min']:.1f}"       if r.get("ttfi_min")       is not None else "N/A"
+        ttfi_gpu_h_str = f"{r['ttfi_gpu_h']:.2f}"    if r.get("ttfi_gpu_h")    is not None else "N/A"
+        oh_time_str    = f"{r['overhead_time_h']:.3f}" if r.get("overhead_time_h") is not None else "N/A"
+        oh_gpu_h_str   = f"{r['overhead_gpu_h']:.2f}" if r.get("overhead_gpu_h") is not None else "N/A"
+        oh_pct_str     = f"{r['overhead_pct']:.1f}%"  if r.get("overhead_pct")  is not None else "N/A"
 
         error_disp = r["error_desc"][:28] if r["error_desc"] else ""
 
@@ -1393,9 +1816,7 @@ def main() -> None:
         else:
             c_str = "N/A"
         m_budget = RE_BUDGET.search(r["run_name"])
-        stage_disp = (
-            m_budget.group(1) if m_budget else ("stable" if r["stage"] == "stable" else "decay")
-        )
+        stage_disp = m_budget.group(1) if m_budget else ("stable" if r["stage"] == "stable" else "decay")
         nodes_str = str(r["nodes"]) if r.get("nodes") is not None else "N/A"
 
         print(
@@ -1428,6 +1849,7 @@ def main() -> None:
             f"{oh_gpu_h_str:>14} "
             f"{gpu_h_str:>10} "
             f"{oh_pct_str:>9} "
+            f"{r.get('cluster', ''):>7} "
             f"{'🔁' if r['action_word'] == 'AUTO_RESTARTED' else '🔄' if r['action_word'] == 'MANUALLY_RESTARTED' else '🆕' if r['action_word'] == 'NEW_SESSION' else ''}{r['status_emoji']} "
             f"{color}{r['status_word']:<12}{RESET} "
             f"{r['action_word']:<14} "
@@ -1454,16 +1876,14 @@ def main() -> None:
                     gpu_h = _gpu_parse_elapsed(d["elapsed"]) * d["gpus"]
                     exp_gpu_h[exp_name] = exp_gpu_h.get(exp_name, 0.0) + gpu_h
                     grand_gpu_total += gpu_h
-                    gpu_csv_rows.append(
-                        {
-                            "experiment": exp_name,
-                            "job_id": job_id,
-                            "state": d["state"],
-                            "elapsed": d["elapsed"],
-                            "gpus": d["gpus"],
-                            "gpu_hours": round(gpu_h, 1),
-                        }
-                    )
+                    gpu_csv_rows.append({
+                        "experiment": exp_name,
+                        "job_id":     job_id,
+                        "state":      d["state"],
+                        "elapsed":    d["elapsed"],
+                        "gpus":       d["gpus"],
+                        "gpu_hours":  round(gpu_h, 1),
+                    })
         except SystemExit:
             pass
 
@@ -1475,27 +1895,241 @@ def main() -> None:
                 exp_gpu_h[rn] = exp_gpu_h.get(rn, 0.0) + r["gpu_hours"]
                 grand_gpu_total += r["gpu_hours"]
 
-    if exp_gpu_h:
+    # Infer GPU-h for foreign-cluster jobs from log data (sacct on this machine
+    # returns 0 for jobs that ran on the other cluster).
+    # GPU-h = efficient training GPU-h (from throughput) + LowTP GPU-h (from logs).
+    # LowTP is log-based and valid; efficient GPU-h covers the remaining training time.
+    _foreign_cluster = "MN5" if args.machine != "MN5" else "LEO"
+    _run_prev_last_iter: dict[str, int] = {}
+    for r in rows:
+        rn = r["run_name"]
+        if r.get("gpu_hours") is None and r.get("cluster") == _foreign_cluster:
+            avg_tp   = r.get("avg_tok_per_gpu")
+            tok_b    = r.get("tokens_b")
+            tr_iters = r.get("train_iters")
+            last_it  = r.get("last_iter")
+            if avg_tp and avg_tp > 0 and tr_iters and tr_iters > 0 and tok_b and last_it:
+                tokens_per_iter = tok_b * 1e9 / tr_iters
+                start_iter = _run_prev_last_iter.get(rn, 0)
+                job_tokens = (last_it - start_iter) * tokens_per_iter
+                if job_tokens > 0:
+                    efficient_gpu_h = job_tokens / (avg_tp * 3600)
+                    lowtp_gpu_h = r.get("gpu_h_lost") or 0.0
+                    r["gpu_hours"] = efficient_gpu_h + lowtp_gpu_h
+        if r.get("cluster") == _foreign_cluster and r.get("last_iter") is not None:
+            _run_prev_last_iter[rn] = r["last_iter"]
+
+    # For foreign-cluster rows: TTFI requires sacct job-start time so always null it.
+    # LowTP is log-based and kept. Recompute overhead without TTFI component.
+    # For rows still without gpu_hours (couldn't infer), null overhead% but keep LowTP.
+    # Also null TTFI/overhead for undetected foreign jobs (gpu_hours=None) in foreign runs.
+    _foreign_run_names = {r["run_name"] for r in rows if r.get("cluster") == _foreign_cluster}
+    for r in rows:
+        is_foreign_row = r.get("cluster") == _foreign_cluster
+        is_undetected_foreign = (
+            r["run_name"] in _foreign_run_names and r.get("gpu_hours") is None
+        )
+        if is_foreign_row or is_undetected_foreign:
+            # TTFI always unknown without sacct start time
+            r["ttfi_min"] = None
+            r["ttfi_gpu_h"] = None
+            if r.get("gpu_hours") is not None:
+                # Recompute overhead as LowTP only (no TTFI)
+                ltp = r.get("gpu_h_lost") or 0.0
+                r["overhead_gpu_h"] = ltp if ltp > 0 else None
+                r["overhead_time_h"] = r.get("time_lost_h")
+                r["overhead_pct"] = (ltp / r["gpu_hours"] * 100) if ltp > 0 else None
+            else:
+                r["overhead_time_h"] = None
+                r["overhead_gpu_h"] = None
+                r["overhead_pct"] = None
+
+    # Add inferred foreign-cluster GPU-h into exp_gpu_h so the summary table
+    # reflects real usage (sacct returned 0 for these jobs).
+    for r in rows:
+        if r.get("cluster") == _foreign_cluster and r.get("gpu_hours") is not None:
+            rn = r["run_name"]
+            exp_gpu_h[rn] = exp_gpu_h.get(rn, 0.0) + r["gpu_hours"]
+            grand_gpu_total += r["gpu_hours"]
+
+    summary_gpu_h = _build_summary_exp_gpu_h(run_specs, exp_gpu_h, rows)
+    summary_grand_total = sum(h for h in summary_gpu_h.values() if h is not None)
+
+    # Per-run GPU-h split by cluster, aggregated from per-job rows.
+    _run_gpu_h_leo: dict[str, float] = {}
+    _run_gpu_h_mn5: dict[str, float] = {}
+    _foreign_job_seen = False
+    for _r in rows:
+        _rn = _r["run_name"]
+        _cl = _r.get("cluster", "")
+        if _cl == _foreign_cluster:
+            _foreign_job_seen = True
+            if _r.get("gpu_hours") is not None:
+                _run_gpu_h_mn5[_rn] = _run_gpu_h_mn5.get(_rn, 0.0) + _r["gpu_hours"]
+        elif _cl and _r.get("gpu_hours") is not None:
+            _run_gpu_h_leo[_rn] = _run_gpu_h_leo.get(_rn, 0.0) + _r["gpu_hours"]
+    _any_cluster_split = _foreign_job_seen
+
+    # ── Checkpoint storage (GiB) ──────────────────────────────────────────────
+    run_checkpoint_storage: dict[str, tuple[float | None, float | None]] = {}
+    if args.compute_storage:
+        print("\nMeasuring checkpoint storage (du -sb on checkpoints/ per run)…", flush=True)
+        run_checkpoint_storage = build_run_checkpoint_storage(
+            run_specs,
+            run_to_gbsz,
+            run_stage_map,
+            resolved_base,
+            rows,
+            cfg["seq_length"],
+            cfg.get("cooldown_decay_fraction", 0.2),
+        )
+
+    # ── Remaining GPU-h estimation ────────────────────────────────────────────
+    # Per-run throughput: mean of avg_tok_per_gpu across all jobs for that run.
+    # Each per-job value is already filtered (max_elapsed_ms / skip_first_iters /
+    # max_iters in load_or_compute_throughput), so the mean is robust to outliers.
+    _run_tp_vals: dict[str, list[float]] = {}
+    for r in rows:
+        if r.get("avg_tok_per_gpu") is not None:
+            _run_tp_vals.setdefault(r["run_name"], []).append(r["avg_tok_per_gpu"])
+    _run_avg_tok: dict[str, float] = {rn: mean(v) for rn, v in _run_tp_vals.items()}
+
+    # Global fallback: mean across all runs that have throughput data.
+    _ref_avg_tok_per_gpu: float | None = mean(list(_run_avg_tok.values())) if _run_avg_tok else None
+
+    # Per-gbsz average throughput from stable runs (used to estimate NOT_LAUNCHED runs).
+    _gbsz_stable_toks: dict[int, list[float]] = {}
+    for _rn_s, _avg_s in _run_avg_tok.items():
+        if run_stage_map.get(_rn_s, "") == "stable":
+            _gbsz_s = run_to_gbsz.get(_rn_s)
+            if _gbsz_s is not None:
+                _gbsz_stable_toks.setdefault(_gbsz_s, []).append(_avg_s)
+    _gbsz_stable_avg_tok: dict[int, float] = {
+        gbsz: mean(vals) for gbsz, vals in _gbsz_stable_toks.items()
+    }
+
+    # Per-stage branch-point token count for decay runs.
+    # A decay run starts from a stable checkpoint and runs to decay_tok total tokens,
+    # so it only processes (decay_tok - ckpt_tokens) new tokens.
+    # ckpt_tokens = ckpt_step × gbsz × seq_length is the same across all combos of
+    # the same stage (they branch at the same training-token budget), so we take the
+    # first available value from any launched decay row of that stage.
+    _seq_len = cfg["seq_length"]
+    _stage_ckpt_tokens: dict[str, int] = {}  # stage_name → branch-point raw token count
+    for r in rows:
+        _rs = run_stage_map.get(r["run_name"], "")
+        if (
+            _rs != "stable"
+            and r.get("ckpt_step") is not None
+            and r.get("global_batch_size") is not None
+            and _rs not in _stage_ckpt_tokens
+        ):
+            _stage_ckpt_tokens[_rs] = r["ckpt_step"] * r["global_batch_size"] * _seq_len
+
+    # (value, is_estimated) per run
+    #   is_estimated=False → extrapolated from actual spend: h_spent × (1−p)/p
+    #   is_estimated=True  → derived from throughput of corresponding stable run
+    #                        (or global mean if that too is unavailable)
+    run_remaining: dict[str, tuple[float | None, bool]] = {}
+    for _rn, _rs, _rt, _ in run_specs:
+        _run_rows_r = [r for r in rows if r["run_name"] == _rn]
+        _latest_r   = _run_rows_r[-1] if _run_rows_r else {}
+        _status_r   = _latest_r.get("status_word", "NOT_LAUNCHED")
+        _h_r        = summary_gpu_h.get(_rn)
+        _prog_r     = _latest_r.get("progress")
+        # Reference throughput: for NOT_LAUNCHED runs prefer gbsz-matched stable avg,
+        # otherwise prefer stable sibling, then own data, then global mean.
+        _stable_rn  = decay_to_stable.get(_rn)  # None for stable runs
+        _gbsz_rn    = run_to_gbsz.get(_rn)
+        if _status_r == "NOT_LAUNCHED":
+            _ref_tok = (
+                (_gbsz_stable_avg_tok.get(_gbsz_rn) if _gbsz_rn is not None else None)
+                or _run_avg_tok.get(_stable_rn)
+                or _run_avg_tok.get(_rn)
+                or _ref_avg_tok_per_gpu
+            )
+        else:
+            _ref_tok = (
+                _run_avg_tok.get(_stable_rn)
+                or _run_avg_tok.get(_rn)
+                or _ref_avg_tok_per_gpu
+            )
+        # Effective token count: for decay runs subtract the stable branch-point tokens.
+        # For stable runs (or decay runs with no ckpt_tokens info), use full budget.
+        _ckpt_toks  = _stage_ckpt_tokens.get(_rs, 0) if _rs != "stable" else 0
+        _eff_tokens = max(0, _rt - _ckpt_toks)
+        if _status_r == "DONE":
+            run_remaining[_rn] = (0.0, False)
+        elif _h_r is not None and _prog_r is not None and _prog_r > 0:
+            run_remaining[_rn] = (_h_r * (100.0 - _prog_r) / _prog_r, False)
+        elif _ref_tok is not None and _eff_tokens > 0:
+            run_remaining[_rn] = (_eff_tokens / (_ref_tok * 3600.0), True)
+        else:
+            run_remaining[_rn] = (None, False)
+    grand_remaining_total = sum(v for v, _ in run_remaining.values() if v is not None)
+
+    if summary_gpu_h:
         run_latest_row: dict[str, dict] = {}
         for run_name, _stage, _tok, _tier in run_specs:
             run_rows = [r for r in rows if r["run_name"] == run_name]
             if run_rows:
                 run_latest_row[run_name] = run_rows[-1]
 
-        W_EXP = max(len(e) for e in exp_gpu_h) + 2
-        gpu_sep = "─" * (W_EXP + 90)
+        W_EXP = max(len(e) for e in summary_gpu_h) + 2
+        gpu_sep = "─" * (W_EXP + 172)
+        sorted_exps = sorted(
+            summary_gpu_h.items(),
+            key=lambda item: _summary_table_sort_key(item[0], run_tier_map, run_stage_map),
+        )
         print()
         print("Training progress summary:")
+        if _ref_avg_tok_per_gpu is not None:
+            print(f"  (~ estimates use stable-run throughput per combo; global fallback: {_ref_avg_tok_per_gpu:,.0f} Tok/s/GPU)")
+        if args.compute_storage:
+            print("  (Ckpt-GB: measured checkpoints/ size; Ckpt-GB-remaining: estimated storage still needed)")
+        _local = args.machine or "LEO"
+        _foreign = "MN5" if _local != "MN5" else "LEO"
+        _gpu_h_hdr = (
+            f"  {'GPU-h('+_local+')':>10}  {'GPU-h('+_foreign+')':>10}  {'GPU-h':>8}"
+            if _any_cluster_split else
+            f"  {'GPU-h':>8}"
+        )
         print(
-            f"  {'Run':<{W_EXP}}  {'TTFI-GPU-h':>10}  {'LowTP-GPU-h':>12}  {'Overhead-GPU-h':>14}"
-            f"  {'GPU-h':>8}  {'Overhead%':>9}  {'Progress':>9}  {'':>2} {'Status':<12}"
+            f"  {'T#':>3}  {'#':>3}  {'Run':<{W_EXP}}  {'Tier':<9}  {'Progress':>9}  {'':>2} {'Status':<12}  {'Clusters':>8}"
+            f"  {'TTFI-GPU-h':>10}  {'LowTP-GPU-h':>12}  {'Overhead-GPU-h':>14}"
+            f"{_gpu_h_hdr}  {'Overhead%':>9}  {'Remaining-GPU-h':>16}"
+            f"  {'Ckpt-GB':>10}  {'Ckpt-GB-rem':>12}"
         )
         print(gpu_sep)
         grand_lt_time = 0.0
         grand_lt_gpu_h = 0.0
         grand_ttfi_gpu_h = 0.0
         grand_oh_gpu_h = 0.0
-        for exp_name, h in sorted(exp_gpu_h.items()):
+        grand_remaining_gpu_h = 0.0
+        grand_ckpt_gb = 0.0
+        grand_ckpt_rem_gb = 0.0
+        prev_tier: str | None = None
+        tier_idx = 0
+        _tier_ttfi_gpu_h = 0.0
+        _tier_lt_gpu_h = 0.0
+        _tier_oh_gpu_h = 0.0
+        _tier_gpu_h = 0.0
+        _tier_gpu_h_leo = 0.0
+        _tier_gpu_h_mn5 = 0.0
+        _tier_rem_gpu_h = 0.0
+        _tier_ckpt_gb = 0.0
+        _tier_ckpt_rem_gb = 0.0
+        _tier_name_cur = ""
+        grand_gpu_h_leo = 0.0
+        grand_gpu_h_mn5 = 0.0
+        for idx, (exp_name, h) in enumerate(sorted_exps, start=1):
+            tier_str = run_tier_map.get(exp_name, "")
+            if tier_str != prev_tier:
+                tier_idx = 1
+                prev_tier = tier_str
+                _tier_name_cur = tier_str
+            else:
+                tier_idx += 1
             latest = run_latest_row.get(exp_name, {})
             prog = latest.get("progress")
             prog_str = f"{prog:.1f}%" if prog is not None else "N/A"
@@ -1508,54 +2142,145 @@ def main() -> None:
                 _ck = status
             color = status_colors.get(_ck, "")
             run_rows = [r for r in rows if r["run_name"] == exp_name]
+            _run_cls = {r.get("cluster", "") for r in run_rows if r.get("cluster")}
+            _cluster_tag = "MIX" if len(_run_cls) > 1 else (next(iter(_run_cls)) if _run_cls else "")
             # TTFI GPU-h: sum across all jobs for this run
             ttfi_gpu_h_vals = [r["ttfi_gpu_h"] for r in run_rows if r.get("ttfi_gpu_h") is not None]
             ttfi_gpu_h_sum = sum(ttfi_gpu_h_vals) if ttfi_gpu_h_vals else None
             ttfi_gpu_h_str = f"{ttfi_gpu_h_sum:.2f}" if ttfi_gpu_h_sum is not None else "N/A"
             if ttfi_gpu_h_sum is not None:
                 grand_ttfi_gpu_h += ttfi_gpu_h_sum
+                _tier_ttfi_gpu_h += ttfi_gpu_h_sum
             # Low-throughput stats: sum across all jobs for this run
             lt_time_vals = [r["time_lost_h"] for r in run_rows if r.get("time_lost_h") is not None]
             lt_gpu_h_vals = [r["gpu_h_lost"] for r in run_rows if r.get("gpu_h_lost") is not None]
             lt_time = sum(lt_time_vals) if lt_time_vals else None
             lt_gpu_h = sum(lt_gpu_h_vals) if lt_gpu_h_vals else None
-            lt_time_str = f"{lt_time:.3f}" if lt_time is not None else "N/A"
             lt_gpu_h_str = f"{lt_gpu_h:.2f}" if lt_gpu_h is not None else "N/A"
             if lt_time is not None:
                 grand_lt_time += lt_time
             if lt_gpu_h is not None:
                 grand_lt_gpu_h += lt_gpu_h
-            # Overhead (TTFI + LowTP) GPU-h and percentage for this run
-            oh_gpu_h_vals = [
-                r["overhead_gpu_h"] for r in run_rows if r.get("overhead_gpu_h") is not None
-            ]
+                _tier_lt_gpu_h += lt_gpu_h
+            # Overhead (TTFI + LowTP) GPU-h and percentage for this run.
+            # Only include jobs with known GPU-h so the denominator and numerator
+            # are from the same cluster (avoids inflated % from MN5 LowTP with
+            # only LEO GPU-h in the denominator).
+            oh_gpu_h_vals = [r["overhead_gpu_h"] for r in run_rows
+                             if r.get("overhead_gpu_h") is not None and r.get("gpu_hours") is not None]
             oh_gpu_h_sum = sum(oh_gpu_h_vals) if oh_gpu_h_vals else None
             oh_gpu_h_str = f"{oh_gpu_h_sum:.2f}" if oh_gpu_h_sum is not None else "N/A"
-            oh_pct_val = oh_gpu_h_sum / h * 100.0 if oh_gpu_h_sum is not None and h > 0 else None
+            oh_pct_val = (
+                oh_gpu_h_sum / h * 100.0 if oh_gpu_h_sum is not None and h is not None and h > 0 else None
+            )
             oh_pct_str = f"{oh_pct_val:.1f}%" if oh_pct_val is not None else "N/A"
+            gpu_h_str = f"{h:.1f}" if h is not None else "N/A"
+            _h_leo = _run_gpu_h_leo.get(exp_name)
+            _h_mn5 = _run_gpu_h_mn5.get(exp_name)
+            _h_leo_str = f"{_h_leo:.1f}" if _h_leo is not None else "N/A"
+            _h_mn5_str = f"{_h_mn5:.1f}" if _h_mn5 is not None else "N/A"
             if oh_gpu_h_sum is not None:
                 grand_oh_gpu_h += oh_gpu_h_sum
-            print(
-                f"  {exp_name:<{W_EXP}}  {ttfi_gpu_h_str:>10}  {lt_gpu_h_str:>12}  {oh_gpu_h_str:>14}"
-                f"  {h:>8.1f}  {oh_pct_str:>9}  {prog_str:>9}  {emoji} {color}{status:<12}{RESET}"
+                _tier_oh_gpu_h += oh_gpu_h_sum
+            if h is not None:
+                _tier_gpu_h += h
+            if _h_leo is not None:
+                _tier_gpu_h_leo += _h_leo
+                grand_gpu_h_leo += _h_leo
+            if _h_mn5 is not None:
+                _tier_gpu_h_mn5 += _h_mn5
+                grand_gpu_h_mn5 += _h_mn5
+            rem_val, rem_est = run_remaining.get(exp_name, (None, False))
+            rem_str = (f"~{rem_val:.1f}" if rem_est else f"{rem_val:.1f}") if rem_val is not None else "N/A"
+            if rem_val is not None:
+                grand_remaining_gpu_h += rem_val
+                _tier_rem_gpu_h += rem_val
+            ckpt_str = _format_ckpt_measured_cell(
+                run_checkpoint_storage, exp_name, compute=args.compute_storage
             )
-        print(gpu_sep)
+            ckpt_rem_str = _format_ckpt_remaining_cell(
+                run_checkpoint_storage, exp_name, compute=args.compute_storage
+            )
+            if args.compute_storage:
+                ckpt_val, ckpt_rem_val = run_checkpoint_storage.get(exp_name, (None, None))
+                if ckpt_val is not None:
+                    grand_ckpt_gb += ckpt_val
+                    _tier_ckpt_gb += ckpt_val
+                if ckpt_rem_val is not None:
+                    grand_ckpt_rem_gb += ckpt_rem_val
+                    _tier_ckpt_rem_gb += ckpt_rem_val
+            _gpu_h_cols = (
+                f"  {_h_leo_str:>10}  {_h_mn5_str:>10}  {gpu_h_str:>8}"
+                if _any_cluster_split else
+                f"  {gpu_h_str:>8}"
+            )
+            print(
+                f"  {tier_idx:>3}  {idx:>3}  {exp_name:<{W_EXP}}  {tier_str:<9}  {prog_str:>9}  {emoji} {color}{status:<12}{RESET}  {_cluster_tag:>8}"
+                f"  {ttfi_gpu_h_str:>10}  {lt_gpu_h_str:>12}  {oh_gpu_h_str:>14}"
+                f"{_gpu_h_cols}  {oh_pct_str:>9}  {rem_str:>16}"
+                f"  {ckpt_str:>10}  {ckpt_rem_str:>12}"
+            )
+            is_last_entry = idx >= len(sorted_exps)
+            next_tier_str = "" if is_last_entry else run_tier_map.get(sorted_exps[idx][0], "")
+            if is_last_entry or next_tier_str != tier_str:
+                _t_oh_pct = _tier_oh_gpu_h / _tier_gpu_h * 100.0 if _tier_gpu_h > 0 else None
+                _t_oh_pct_s = f"{_t_oh_pct:.1f}%" if _t_oh_pct is not None else "N/A"
+                _t_ttfi_s = f"{_tier_ttfi_gpu_h:.2f}" if _tier_ttfi_gpu_h else "N/A"
+                _t_oh_s = f"{_tier_oh_gpu_h:.2f}" if _tier_oh_gpu_h else "N/A"
+                _t_gpu_h_s = f"{_tier_gpu_h:.1f}" if _tier_gpu_h else "N/A"
+                _t_leo_s = f"{_tier_gpu_h_leo:.1f}" if _tier_gpu_h_leo else "N/A"
+                _t_mn5_s = f"{_tier_gpu_h_mn5:.1f}" if _tier_gpu_h_mn5 else "N/A"
+                _t_rem_s = f"{_tier_rem_gpu_h:.1f}" if _tier_rem_gpu_h else "N/A"
+                _t_ckpt_s = _format_ckpt_gb_total(_tier_ckpt_gb, compute=args.compute_storage)
+                _t_ckpt_rem_s = _format_ckpt_gb_total(_tier_ckpt_rem_gb, compute=args.compute_storage)
+                _t_gpu_h_cols = (
+                    f"  {_t_leo_s:>10}  {_t_mn5_s:>10}  {_t_gpu_h_s:>8}"
+                    if _any_cluster_split else
+                    f"  {_t_gpu_h_s:>8}"
+                )
+                print(
+                    f"  {'':>3}  {'':>3}  {f'[{_tier_name_cur} total]':<{W_EXP}}  {_tier_name_cur:<9}  {'':>9}  {'':>2} {'':<12}  {'':>8}"
+                    f"  {_t_ttfi_s:>10}  {_tier_lt_gpu_h:>12.2f}"
+                    f"  {_t_oh_s:>14}{_t_gpu_h_cols}  {_t_oh_pct_s:>9}  {_t_rem_s:>16}"
+                    f"  {_t_ckpt_s:>10}  {_t_ckpt_rem_s:>12}"
+                )
+                _tier_ttfi_gpu_h = 0.0
+                _tier_lt_gpu_h = 0.0
+                _tier_oh_gpu_h = 0.0
+                _tier_gpu_h = 0.0
+                _tier_gpu_h_leo = 0.0
+                _tier_gpu_h_mn5 = 0.0
+                _tier_rem_gpu_h = 0.0
+                _tier_ckpt_gb = 0.0
+                _tier_ckpt_rem_gb = 0.0
+                print(gpu_sep)
         grand_ttfi_gpu_h_str = f"{grand_ttfi_gpu_h:.2f}" if grand_ttfi_gpu_h else "N/A"
         grand_oh_gpu_h_str = f"{grand_oh_gpu_h:.2f}" if grand_oh_gpu_h else "N/A"
         grand_oh_pct = (
-            grand_oh_gpu_h / grand_gpu_total * 100.0
-            if grand_oh_gpu_h and grand_gpu_total > 0
+            grand_oh_gpu_h / summary_grand_total * 100.0
+            if grand_oh_gpu_h and summary_grand_total > 0
             else None
         )
         grand_oh_pct_str = f"{grand_oh_pct:.1f}%" if grand_oh_pct is not None else "N/A"
+        grand_rem_str = f"{grand_remaining_gpu_h:.1f}" if grand_remaining_gpu_h else "N/A"
+        grand_ckpt_str = _format_ckpt_gb_total(grand_ckpt_gb, compute=args.compute_storage)
+        grand_ckpt_rem_str = _format_ckpt_gb_total(grand_ckpt_rem_gb, compute=args.compute_storage)
+        _grand_leo_s = f"{grand_gpu_h_leo:.1f}" if grand_gpu_h_leo else "N/A"
+        _grand_mn5_s = f"{grand_gpu_h_mn5:.1f}" if grand_gpu_h_mn5 else "N/A"
+        _grand_gpu_h_cols = (
+            f"  {_grand_leo_s:>10}  {_grand_mn5_s:>10}  {summary_grand_total:>8.1f}"
+            if _any_cluster_split else
+            f"  {summary_grand_total:>8.1f}"
+        )
         print(
-            f"  {'TOTAL':<{W_EXP}}  {grand_ttfi_gpu_h_str:>10}  {grand_lt_gpu_h:>12.2f}"
-            f"  {grand_oh_gpu_h_str:>14}  {grand_gpu_total:>8.1f}  {grand_oh_pct_str:>9}  {'':>9}"
+            f"  {'':>3}  {'':>3}  {'TOTAL':<{W_EXP}}  {'':<9}  {'':>9}  {'':>2} {'':<12}"
+            f"  {grand_ttfi_gpu_h_str:>10}  {grand_lt_gpu_h:>12.2f}"
+            f"  {grand_oh_gpu_h_str:>14}{_grand_gpu_h_cols}  {grand_oh_pct_str:>9}  {grand_rem_str:>16}"
+            f"  {grand_ckpt_str:>10}  {grand_ckpt_rem_str:>12}"
         )
 
     # Summary counts
     from collections import Counter
-
     counts = Counter(r["status_word"] for r in rows)
     print()
     print("Status breakdown:")
@@ -1564,42 +2289,28 @@ def main() -> None:
 
     # ── CSV output ──────────────────────────────────────────────────────────
     if args.csv:
+        # Pre-compute run-level cluster tag (LEO / MN5 / MIX) for CSV
+        _csv_run_cluster_tag: dict[str, str] = {}
+        for _rn in {r["run_name"] for r in rows}:
+            _cls = {r.get("cluster", "") for r in rows if r["run_name"] == _rn and r.get("cluster")}
+            _csv_run_cluster_tag[_rn] = "MIX" if len(_cls) > 1 else (next(iter(_cls)) if _cls else "")
+
         csv_fields = [
-            "Run",
-            "JobID",
-            "N_ne(B)",
-            "N(B)",
-            "D(B)",
-            "C(10^18)",
-            "Tier",
-            "Stage",
-            "TotIter",
-            "CurIter",
-            "LastCkpt",
-            "Prog%",
-            "TrainLoss",
-            "ValLoss",
-            "LR",
-            "GBS",
-            "MBS",
-            "Nodes",
-            "Workers",
-            "TFLOP/s/GPU",
-            "Tok/s/GPU",
-            "TTFI(min)",
-            "TTFI-GPU-h",
-            "LowTP-time(h)",
-            "LowTP-GPU-h",
-            "Overhead-time(h)",
-            "Overhead-GPU-h",
-            "GPU-h",
-            "Overhead%",
-            "Emoji",
-            "Status",
-            "Action",
-            "Error",
+            "Run", "JobID", "Machine", "RunClusters", "Owner", "StartTime", "Elapsed",
+            "N_ne(B)", "N(B)", "D(B)", "C(10^18)", "Tier", "Stage",
+            "TotIter", "CurIter", "LastCkpt", "Prog%", "TrainLoss", "ValLoss", "LR", "GBS", "MBS", "Nodes", "Workers",
+            "TFLOP/s/GPU", "Tok/s/GPU", "TTFI(min)", "TTFI-GPU-h",
+            "LowTP-time(h)", "LowTP-GPU-h", "Overhead-time(h)", "Overhead-GPU-h", "GPU-h(LEO)", "GPU-h(MN5)", "GPU-h", "Overhead%",
+            "Remaining-GPU-h",
+            "Emoji", "Status", "Action", "Error",
         ]
         csv_path = Path(args.csv)
+        csv_path.parent.mkdir(parents=True, exist_ok=True)
+        # Pre-compute which job_id is the latest for each run (remaining GPU-h
+        # is a per-run estimate, so we only populate it on the latest-job row).
+        _csv_latest_job: dict[str, str] = {
+            rn: jids[-1] for rn, jids in run_job_map.items() if jids
+        }
         with csv_path.open("w", newline="") as f:
             writer = csv.DictWriter(f, fieldnames=csv_fields)
             writer.writeheader()
@@ -1611,83 +2322,70 @@ def main() -> None:
                     if r["transformer_params_b"] is not None and r.get("tokens_b") is not None
                     else ""
                 )
-                writer.writerow(
-                    {
-                        "Run": r["run_name"],
-                        "JobID": r["job_id"],
-                        "N_ne(B)": f"{r['transformer_params_b']:.2f}"
-                        if r["transformer_params_b"] is not None
-                        else "",
-                        "N(B)": f"{r['total_params_b']:.2f}"
-                        if r["total_params_b"] is not None
-                        else "",
-                        "D(B)": int(r["tokens_b"]) if r.get("tokens_b") is not None else "",
-                        "C(10^18)": c_val,
-                        "Tier": r.get("tier", ""),
-                        "Stage": sd,
-                        "TotIter": r["train_iters"] if r["train_iters"] is not None else "",
-                        "CurIter": r.get("last_iter") if r.get("last_iter") is not None else "",
-                        "LastCkpt": r["last_ckpt"] if r["last_ckpt"] is not None else "",
-                        "Prog%": f"{r['progress']:.1f}" if r.get("progress") is not None else "",
-                        "TrainLoss": f"{r['last_train_loss']:.4f}"
-                        if r.get("last_train_loss") is not None
-                        else "",
-                        "ValLoss": f"{r['last_val_loss']:.4f}"
-                        if r.get("last_val_loss") is not None
-                        else "",
-                        "LR": f"{r['lr']:.4f}" if r["lr"] is not None else "",
-                        "GBS": r["global_batch_size"] if r["global_batch_size"] is not None else "",
-                        "MBS": r["micro_batch_size"] if r["micro_batch_size"] is not None else "",
-                        "Nodes": r["nodes"] if r.get("nodes") is not None else "",
-                        "Workers": r["num_workers"] if r["num_workers"] is not None else "",
-                        "TFLOP/s/GPU": f"{r['avg_tflop_per_gpu']:.1f}"
-                        if r["avg_tflop_per_gpu"] is not None
-                        else "",
-                        "Tok/s/GPU": f"{r['avg_tok_per_gpu']:.0f}"
-                        if r["avg_tok_per_gpu"] is not None
-                        else "",
-                        "TTFI(min)": f"{r['ttfi_min']:.1f}"
-                        if r.get("ttfi_min") is not None
-                        else "",
-                        "TTFI-GPU-h": f"{r['ttfi_gpu_h']:.2f}"
-                        if r.get("ttfi_gpu_h") is not None
-                        else "",
-                        "LowTP-time(h)": f"{r['time_lost_h']:.4f}"
-                        if r.get("time_lost_h") is not None
-                        else "",
-                        "LowTP-GPU-h": f"{r['gpu_h_lost']:.4f}"
-                        if r.get("gpu_h_lost") is not None
-                        else "",
-                        "Overhead-time(h)": f"{r['overhead_time_h']:.4f}"
-                        if r.get("overhead_time_h") is not None
-                        else "",
-                        "Overhead-GPU-h": f"{r['overhead_gpu_h']:.4f}"
-                        if r.get("overhead_gpu_h") is not None
-                        else "",
-                        "GPU-h": f"{r['gpu_hours']:.1f}" if r["gpu_hours"] is not None else "",
-                        "Overhead%": f"{r['overhead_pct']:.2f}"
-                        if r.get("overhead_pct") is not None
-                        else "",
-                        "Emoji": r["status_emoji"],
-                        "Status": r["status_word"],
-                        "Action": r["action_word"],
-                        "Error": r["error_desc"],
-                    }
+                _is_latest_csv = (
+                    r["job_id"] == ""
+                    or r["job_id"] == _csv_latest_job.get(r["run_name"])
                 )
+                _rem_v_csv, _rem_est_csv = (
+                    run_remaining.get(r["run_name"], (None, False)) if _is_latest_csv else (None, False)
+                )
+                rem_gpu_h_csv = (
+                    (f"~{_rem_v_csv:.1f}" if _rem_est_csv else f"{_rem_v_csv:.1f}")
+                    if _rem_v_csv is not None else ""
+                )
+                writer.writerow({
+                    "Run":         r["run_name"],
+                    "JobID":       r["job_id"],
+                    "Machine":     r.get("cluster", ""),
+                    "RunClusters": _csv_run_cluster_tag.get(r["run_name"], ""),
+                    "Owner":       r.get("owner", ""),
+                    "StartTime":   r.get("sacct_start_str", ""),
+                    "Elapsed":     r.get("sacct_elapsed", ""),
+                    "N_ne(B)":     f"{r['transformer_params_b']:.2f}" if r["transformer_params_b"] is not None else "",
+                    "N(B)":        f"{r['total_params_b']:.2f}" if r["total_params_b"] is not None else "",
+                    "D(B)":        int(r["tokens_b"]) if r.get("tokens_b") is not None else "",
+                    "C(10^18)":    c_val,
+                    "Tier":        r.get("tier", ""),
+                    "Stage":       sd,
+                    "TotIter":     r["train_iters"] if r["train_iters"] is not None else "",
+                    "CurIter":     r.get("last_iter") if r.get("last_iter") is not None else "",
+                    "LastCkpt":    r["last_ckpt"] if r["last_ckpt"] is not None else "",
+                    "Prog%":       f"{r['progress']:.1f}" if r.get("progress") is not None else "",
+                    "TrainLoss":   f"{r['last_train_loss']:.4f}" if r.get("last_train_loss") is not None else "",
+                    "ValLoss":     f"{r['last_val_loss']:.4f}" if r.get("last_val_loss") is not None else "",
+                    "LR":          f"{r['lr']:.4f}" if r["lr"] is not None else "",
+                    "GBS":         r["global_batch_size"] if r["global_batch_size"] is not None else "",
+                    "MBS":         r["micro_batch_size"] if r["micro_batch_size"] is not None else "",
+                    "Nodes":       r["nodes"] if r.get("nodes") is not None else "",
+                    "Workers":     r["num_workers"] if r["num_workers"] is not None else "",
+                    "TFLOP/s/GPU":   f"{r['avg_tflop_per_gpu']:.1f}" if r["avg_tflop_per_gpu"] is not None else "",
+                    "Tok/s/GPU":     f"{r['avg_tok_per_gpu']:.0f}" if r["avg_tok_per_gpu"] is not None else "",
+                    "TTFI(min)":     f"{r['ttfi_min']:.1f}" if r.get("ttfi_min") is not None else "",
+                    "TTFI-GPU-h":    f"{r['ttfi_gpu_h']:.2f}" if r.get("ttfi_gpu_h") is not None else "",
+                    "LowTP-time(h)":    f"{r['time_lost_h']:.4f}"    if r.get("time_lost_h")    is not None else "",
+                    "LowTP-GPU-h":      f"{r['gpu_h_lost']:.4f}"     if r.get("gpu_h_lost")     is not None else "",
+                    "Overhead-time(h)": f"{r['overhead_time_h']:.4f}" if r.get("overhead_time_h") is not None else "",
+                    "Overhead-GPU-h":   f"{r['overhead_gpu_h']:.4f}"  if r.get("overhead_gpu_h")  is not None else "",
+                    "GPU-h(LEO)":       f"{r['gpu_hours']:.1f}" if r.get("gpu_hours") is not None and r.get("cluster") == args.machine else "",
+                    "GPU-h(MN5)":       f"{r['gpu_hours']:.1f}" if r.get("gpu_hours") is not None and r.get("cluster") == _foreign_cluster else "",
+                    "GPU-h":            f"{r['gpu_hours']:.1f}"       if r["gpu_hours"]           is not None else "",
+                    "Overhead%":        f"{r['overhead_pct']:.2f}"    if r.get("overhead_pct")    is not None else "",
+                    "Remaining-GPU-h":  rem_gpu_h_csv,
+                    "Emoji":         r["status_emoji"],
+                    "Status":      r["status_word"],
+                    "Action":      r["action_word"],
+                    "Error":       r["error_desc"],
+                })
         print(f"\nWrote {len(rows)} rows to {csv_path}")
 
     if gpu_csv_rows:
-        gpu_csv_rows.append(
-            {
-                "experiment": "TOTAL",
-                "job_id": "",
-                "state": "",
-                "elapsed": "",
-                "gpus": "",
-                "gpu_hours": round(grand_gpu_total, 1),
-            }
-        )
+        gpu_csv_rows.append({
+            "experiment": "TOTAL",
+            "job_id": "", "state": "", "elapsed": "", "gpus": "",
+            "gpu_hours": round(grand_gpu_total, 1),
+        })
         gpu_csv_path = resolved_base / "gpu_hours.csv"
+        gpu_csv_path.parent.mkdir(parents=True, exist_ok=True)
         with gpu_csv_path.open("w", newline="") as f:
             writer = csv.DictWriter(
                 f, fieldnames=["experiment", "job_id", "state", "elapsed", "gpus", "gpu_hours"]
@@ -1719,86 +2417,215 @@ def main() -> None:
                     spending_ts = _m.group(1)
 
         spending_str = spending_ts if spending_ts is not None else "N/A"
+        md_path.parent.mkdir(parents=True, exist_ok=True)
         with md_path.open("w") as f:
             f.write(f"_Updated training progress: {now_str}_  \n")
             f.write(f"_Updated compute spending: {spending_str}_\n\n")
-            f.write("# Sweep run status\n\n")
+            f.write(f"# Sweep run status\n\n")
             f.write(f"**Config:** `{args.config}`  \n")
             f.write(f"**Results:** `{resolved_base}`\n\n")
 
             # Experiment summary GPU consumption + progress table
             f.write("## Training progress summary\n\n")
-            f.write(
-                "| Experiment | TTFI-GPU-h | LowTP-GPU-h | Overhead-GPU-h | GPU-h | Overhead% | Progress | Status |\n"
+            if _ref_avg_tok_per_gpu is not None:
+                f.write(f"_~ estimates use stable-run throughput per combo; global fallback: {_ref_avg_tok_per_gpu:,.0f} Tok/s/GPU_\n\n")
+            if args.compute_storage:
+                f.write("_Ckpt-GB: measured `checkpoints/` size; Ckpt-GB-remaining: estimated storage still needed_\n\n")
+            _md_gpu_h_hdr = (
+                "GPU-h(LEO) | GPU-h(MN5) | GPU-h"
+                if _any_cluster_split else "GPU-h"
             )
-            f.write("| --- | --- | --- | --- | --- | --- | --- | --- |\n")
+            _md_gpu_h_sep = (
+                " --- | --- | ---"
+                if _any_cluster_split else " ---"
+            )
+            f.write(
+                f"| T# | # | Experiment | Tier | Progress | Status | Clusters | TTFI-GPU-h | LowTP-GPU-h | Overhead-GPU-h | {_md_gpu_h_hdr} | Overhead% | Remaining-GPU-h | Ckpt-GB | Ckpt-GB-remaining |\n"
+            )
+            f.write(f"| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |{_md_gpu_h_sep} | --- | --- | --- | --- |\n")
             grand_lt_time_md = 0.0
             grand_lt_gpu_h_md = 0.0
             grand_ttfi_gpu_h_md = 0.0
             grand_oh_gpu_h_md = 0.0
-            for exp_name, h in sorted(exp_gpu_h.items()):
+            grand_ckpt_gb_md = 0.0
+            grand_ckpt_rem_gb_md = 0.0
+            sorted_exps_md = sorted(
+                summary_gpu_h.items(),
+                key=lambda item: _summary_table_sort_key(item[0], run_tier_map, run_stage_map),
+            )
+            prev_tier_md: str | None = None
+            tier_idx_md = 0
+            _tier_ttfi_gpu_h_md = 0.0
+            _tier_lt_gpu_h_md = 0.0
+            _tier_oh_gpu_h_md = 0.0
+            _tier_gpu_h_md = 0.0
+            _tier_gpu_h_leo_md = 0.0
+            _tier_gpu_h_mn5_md = 0.0
+            _tier_rem_gpu_h_md = 0.0
+            _tier_ckpt_gb_md = 0.0
+            _tier_ckpt_rem_gb_md = 0.0
+            grand_gpu_h_leo_md = 0.0
+            grand_gpu_h_mn5_md = 0.0
+            _tier_name_md = ""
+            for idx, (exp_name, h) in enumerate(sorted_exps_md, start=1):
+                tier_str = run_tier_map.get(exp_name, "")
+                if tier_str != prev_tier_md:
+                    tier_idx_md = 1
+                    prev_tier_md = tier_str
+                    _tier_name_md = tier_str
+                else:
+                    tier_idx_md += 1
                 run_rows = [r for r in rows if r["run_name"] == exp_name]
                 latest = run_rows[-1] if run_rows else {}
                 prog = latest.get("progress")
                 prog_str = f"{prog:.1f}%" if prog is not None else "N/A"
                 emoji = latest.get("status_emoji", "")
                 status = latest.get("status_word", "")
-                ttfi_gpu_h_vals_md = [
-                    r["ttfi_gpu_h"] for r in run_rows if r.get("ttfi_gpu_h") is not None
-                ]
+                _md_run_cls = {r.get("cluster", "") for r in run_rows if r.get("cluster")}
+                _md_cluster_tag = "MIX" if len(_md_run_cls) > 1 else (next(iter(_md_run_cls)) if _md_run_cls else "")
+                ttfi_gpu_h_vals_md = [r["ttfi_gpu_h"] for r in run_rows if r.get("ttfi_gpu_h") is not None]
                 ttfi_gpu_h_md_sum = sum(ttfi_gpu_h_vals_md) if ttfi_gpu_h_vals_md else None
                 ttfi_gpu_h_md_str = (
                     f"{ttfi_gpu_h_md_sum:.2f}" if ttfi_gpu_h_md_sum is not None else "N/A"
                 )
                 if ttfi_gpu_h_md_sum is not None:
                     grand_ttfi_gpu_h_md += ttfi_gpu_h_md_sum
-                lt_time_vals_md = [
-                    r["time_lost_h"] for r in run_rows if r.get("time_lost_h") is not None
-                ]
-                lt_gpu_h_vals_md = [
-                    r["gpu_h_lost"] for r in run_rows if r.get("gpu_h_lost") is not None
-                ]
+                    _tier_ttfi_gpu_h_md += ttfi_gpu_h_md_sum
+                lt_time_vals_md = [r["time_lost_h"] for r in run_rows if r.get("time_lost_h") is not None]
+                lt_gpu_h_vals_md = [r["gpu_h_lost"] for r in run_rows if r.get("gpu_h_lost") is not None]
                 lt_time = sum(lt_time_vals_md) if lt_time_vals_md else None
                 lt_gpu_h = sum(lt_gpu_h_vals_md) if lt_gpu_h_vals_md else None
-                # lt_time_md = f"{lt_time:.3f}" if lt_time is not None else "N/A"
                 lt_gpu_h_md = f"{lt_gpu_h:.2f}" if lt_gpu_h is not None else "N/A"
                 if lt_time is not None:
                     grand_lt_time_md += lt_time
                 if lt_gpu_h is not None:
                     grand_lt_gpu_h_md += lt_gpu_h
-                oh_gpu_h_vals_md = [
-                    r["overhead_gpu_h"] for r in run_rows if r.get("overhead_gpu_h") is not None
-                ]
+                    _tier_lt_gpu_h_md += lt_gpu_h
+                oh_gpu_h_vals_md = [r["overhead_gpu_h"] for r in run_rows
+                                    if r.get("overhead_gpu_h") is not None and r.get("gpu_hours") is not None]
                 oh_gpu_h_md_sum = sum(oh_gpu_h_vals_md) if oh_gpu_h_vals_md else None
                 oh_gpu_h_md_str = f"{oh_gpu_h_md_sum:.2f}" if oh_gpu_h_md_sum is not None else "N/A"
                 oh_pct_md = (
-                    oh_gpu_h_md_sum / h * 100.0 if oh_gpu_h_md_sum is not None and h > 0 else None
+                    oh_gpu_h_md_sum / h * 100.0
+                    if oh_gpu_h_md_sum is not None and h is not None and h > 0
+                    else None
                 )
                 oh_pct_md_str = f"{oh_pct_md:.1f}%" if oh_pct_md is not None else "N/A"
+                gpu_h_md_str = f"{h:.1f}" if h is not None else "N/A"
+                _h_leo_md = _run_gpu_h_leo.get(exp_name)
+                _h_mn5_md = _run_gpu_h_mn5.get(exp_name)
+                _h_leo_md_str = f"{_h_leo_md:.1f}" if _h_leo_md is not None else "N/A"
+                _h_mn5_md_str = f"{_h_mn5_md:.1f}" if _h_mn5_md is not None else "N/A"
                 if oh_gpu_h_md_sum is not None:
                     grand_oh_gpu_h_md += oh_gpu_h_md_sum
-                f.write(
-                    f"| {exp_name} | {ttfi_gpu_h_md_str} | {lt_gpu_h_md} | {oh_gpu_h_md_str}"
-                    f" | {h:.1f} | {oh_pct_md_str} | {prog_str} | {emoji} {status} |\n"
+                    _tier_oh_gpu_h_md += oh_gpu_h_md_sum
+                if h is not None:
+                    _tier_gpu_h_md += h
+                if _h_leo_md is not None:
+                    _tier_gpu_h_leo_md += _h_leo_md
+                    grand_gpu_h_leo_md += _h_leo_md
+                if _h_mn5_md is not None:
+                    _tier_gpu_h_mn5_md += _h_mn5_md
+                    grand_gpu_h_mn5_md += _h_mn5_md
+                rem_val_md, rem_est_md = run_remaining.get(exp_name, (None, False))
+                rem_md_str = (
+                    (f"~{rem_val_md:.1f}" if rem_est_md else f"{rem_val_md:.1f}")
+                    if rem_val_md is not None else "N/A"
                 )
+                if rem_val_md is not None:
+                    _tier_rem_gpu_h_md += rem_val_md
+                ckpt_md_str = _format_ckpt_measured_cell(
+                    run_checkpoint_storage, exp_name, compute=args.compute_storage, md=True
+                )
+                ckpt_rem_md_str = _format_ckpt_remaining_cell(
+                    run_checkpoint_storage, exp_name, compute=args.compute_storage, md=True
+                )
+                if args.compute_storage:
+                    ckpt_val_md, ckpt_rem_val_md = run_checkpoint_storage.get(exp_name, (None, None))
+                    if ckpt_val_md is not None:
+                        grand_ckpt_gb_md += ckpt_val_md
+                        _tier_ckpt_gb_md += ckpt_val_md
+                    if ckpt_rem_val_md is not None:
+                        grand_ckpt_rem_gb_md += ckpt_rem_val_md
+                        _tier_ckpt_rem_gb_md += ckpt_rem_val_md
+                _md_run_gpu_h_cols = (
+                    f" {_h_leo_md_str} | {_h_mn5_md_str} | {gpu_h_md_str}"
+                    if _any_cluster_split else f" {gpu_h_md_str}"
+                )
+                f.write(
+                    f"| {tier_idx_md} | {idx} | {exp_name} | {tier_str} | {prog_str} | {emoji} {status}"
+                    f" | {_md_cluster_tag} | {ttfi_gpu_h_md_str} | {lt_gpu_h_md} | {oh_gpu_h_md_str}"
+                    f" |{_md_run_gpu_h_cols} | {oh_pct_md_str} | {rem_md_str}"
+                    f" | {ckpt_md_str or '—'} | {ckpt_rem_md_str or '—'} |\n"
+                )
+                is_last_md = idx >= len(sorted_exps_md)
+                next_tier_md_str = "" if is_last_md else run_tier_map.get(sorted_exps_md[idx][0], "")
+                if is_last_md or next_tier_md_str != tier_str:
+                    _t_oh_pct_md = _tier_oh_gpu_h_md / _tier_gpu_h_md * 100.0 if _tier_gpu_h_md > 0 else None
+                    _t_oh_pct_md_s = f"{_t_oh_pct_md:.1f}%" if _t_oh_pct_md is not None else "N/A"
+                    _t_ttfi_md_s = f"{_tier_ttfi_gpu_h_md:.2f}" if _tier_ttfi_gpu_h_md else "N/A"
+                    _t_oh_md_s = f"{_tier_oh_gpu_h_md:.2f}" if _tier_oh_gpu_h_md else "N/A"
+                    _t_gpu_h_md_s = f"{_tier_gpu_h_md:.1f}" if _tier_gpu_h_md else "N/A"
+                    _t_leo_md_s = f"{_tier_gpu_h_leo_md:.1f}" if _tier_gpu_h_leo_md else "N/A"
+                    _t_mn5_md_s = f"{_tier_gpu_h_mn5_md:.1f}" if _tier_gpu_h_mn5_md else "N/A"
+                    _t_rem_md_s = f"{_tier_rem_gpu_h_md:.1f}" if _tier_rem_gpu_h_md else "N/A"
+                    _t_ckpt_md_s = _format_ckpt_gb_total(
+                        _tier_ckpt_gb_md, compute=args.compute_storage, md=True
+                    )
+                    _t_ckpt_rem_md_s = _format_ckpt_gb_total(
+                        _tier_ckpt_rem_gb_md, compute=args.compute_storage, md=True
+                    )
+                    _md_tier_gpu_h_cols = (
+                        f" **{_t_leo_md_s}** | **{_t_mn5_md_s}** | **{_t_gpu_h_md_s}**"
+                        if _any_cluster_split else f" **{_t_gpu_h_md_s}**"
+                    )
+                    f.write(
+                        f"| | | **[{_tier_name_md} total]** | **{_tier_name_md}** | | | |"
+                        f" **{_t_ttfi_md_s}** | **{_tier_lt_gpu_h_md:.2f}**"
+                        f" | **{_t_oh_md_s}** |{_md_tier_gpu_h_cols} | **{_t_oh_pct_md_s}** | **{_t_rem_md_s}**"
+                        f" | {_t_ckpt_md_s or '**—**'} | {_t_ckpt_rem_md_s or '**—**'} |\n"
+                    )
+                    f.write(f"{SUMMARY_MD_TIER_SEP}\n")
+                    _tier_ttfi_gpu_h_md = 0.0
+                    _tier_lt_gpu_h_md = 0.0
+                    _tier_oh_gpu_h_md = 0.0
+                    _tier_gpu_h_md = 0.0
+                    _tier_gpu_h_leo_md = 0.0
+                    _tier_gpu_h_mn5_md = 0.0
+                    _tier_rem_gpu_h_md = 0.0
+                    _tier_ckpt_gb_md = 0.0
+                    _tier_ckpt_rem_gb_md = 0.0
             grand_oh_pct_md = (
-                grand_oh_gpu_h_md / grand_gpu_total * 100.0
-                if grand_oh_gpu_h_md and grand_gpu_total > 0
+                grand_oh_gpu_h_md / summary_grand_total * 100.0
+                if grand_oh_gpu_h_md and summary_grand_total > 0
                 else None
             )
             grand_oh_pct_md_str = (
                 f"{grand_oh_pct_md:.1f}%" if grand_oh_pct_md is not None else "N/A"
             )
+            grand_rem_md_str = f"{grand_remaining_total:.1f}" if grand_remaining_total else "N/A"
+            grand_ckpt_md_str = _format_ckpt_gb_total(
+                grand_ckpt_gb_md, compute=args.compute_storage, md=True
+            )
+            grand_ckpt_rem_md_str = _format_ckpt_gb_total(
+                grand_ckpt_rem_gb_md, compute=args.compute_storage, md=True
+            )
+            _grand_leo_md_s = f"{grand_gpu_h_leo_md:.1f}" if grand_gpu_h_leo_md else "N/A"
+            _grand_mn5_md_s = f"{grand_gpu_h_mn5_md:.1f}" if grand_gpu_h_mn5_md else "N/A"
+            _md_grand_gpu_h_cols = (
+                f" **{_grand_leo_md_s}** | **{_grand_mn5_md_s}** | **{summary_grand_total:.1f}**"
+                if _any_cluster_split else f" **{summary_grand_total:.1f}**"
+            )
             f.write(
-                f"| **TOTAL** | **{grand_ttfi_gpu_h_md:.2f}** | **{grand_lt_gpu_h_md:.2f}**"
-                f" | **{grand_oh_gpu_h_md:.2f}** | **{grand_gpu_total:.1f}** | **{grand_oh_pct_md_str}** | | |\n"
+                f"| | | **TOTAL** | | | | | **{grand_ttfi_gpu_h_md:.2f}** | **{grand_lt_gpu_h_md:.2f}**"
+                f" | **{grand_oh_gpu_h_md:.2f}** |{_md_grand_gpu_h_cols} | **{grand_oh_pct_md_str}**"
+                f" | **{grand_rem_md_str}** | {grand_ckpt_md_str or '**—**'} | {grand_ckpt_rem_md_str or '**—**'} |\n"
             )
             f.write("\n")
 
             # Status summary
             f.write("## Status breakdown\n\n")
             from collections import Counter
-
             counts = Counter(r["status_word"] for r in rows)
             for status, cnt in sorted(counts.items()):
                 f.write(f"- **{status}**: {cnt}\n")

--- a/tools/sync_runs.py
+++ b/tools/sync_runs.py
@@ -108,7 +108,6 @@ def main():
         action="store_true",
         help="Continue syncing other runs if one fails",
     )
-
     parser.add_argument(
         "--force", action="store_true", help="Re-sync runs even if they were already synced"
     )


### PR DESCRIPTION
  Updates progress_tracker.py . Addresses the following from #43:
  
  - overhead >100% bug — fixed with sanity checks against total GPU-h
  - QUEUED rows showing N/A progress: fill-forward from previous job now applied
  - machine identification (LEO/MN5): sacct collision detection, per-cluster GPU-h columns
  - New columns:  Elapsed, StartTime, Machine, Owner added to CSV output
  - GPU-h estimates: per-run remaining GPU-h estimate based on throughput
  - missing dependency:  adds scripts/validate_sweep_runs.py (tracker couldn't run without it)
  - checkpoint storage tracking: --compute-storage flag measures current checkpoint size (du -sb) and estimates remaining storage needed at completion, shown as Ckpt-GB and Ckpt-GB-rem columns (optional since time consuming).

  Not in scope: periodic monitor integration, HF spaces dashboard.

  Closes #43